### PR TITLE
Mutable linear preference

### DIFF
--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -1,0 +1,98 @@
+package io.github.oliviercailloux.j_voting.preferences.classes;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.graph.Graph;
+import com.google.common.graph.Graphs;
+import com.google.common.graph.MutableGraph;
+
+import io.github.oliviercailloux.j_voting.Alternative;
+import io.github.oliviercailloux.j_voting.Voter;
+
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreference;
+
+import java.util.Objects;
+
+public class MutableLinearPreferenceImpl implements MutableLinearPreference{
+
+	protected Voter voter;
+    protected MutableGraph<Alternative> graph;
+    protected Set<Alternative> alternatives;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(MutableLinearPreferenceImpl.class.getName());
+    
+    private MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
+    	this.voter = voter;
+    	graph = prefGraph; 
+    	alternatives = graph.nodes();
+    }
+
+    
+    @Override
+	public Set<Alternative> changeOrder(Set<Alternative> alternatives) {
+		
+		return null;
+	}
+
+	@Override
+	public void deleteAlternative(Alternative a) {
+		LOGGER.debug("MutablePreferenceImpl addAlternative");
+        Preconditions.checkNotNull(a);
+        graph.removeNode(a);
+		
+	}
+	
+	@Override
+	public MutableGraph<Alternative> asMutableGraph() {
+		return graph;
+	}
+
+	@Override
+	public void addAlternative(Alternative alternative) {
+		
+		
+	}
+
+	@Override
+	public void addEquivalence(Alternative a1, Alternative a2) {
+		
+		
+	}
+
+	@Override
+	public void setAsLeastAsGood(Alternative a1, Alternative a2) {
+		
+		
+	}
+
+	@Override
+	public Graph<Alternative> asGraph() {
+		return graph;
+		
+		
+	}
+
+	@Override
+	public Set<Alternative> getAlternatives() {
+		return alternatives;
+		
+	}
+
+	@Override
+	public Voter getVoter() {
+	
+		return null;
+	}
+
+	
+    
+	
+   
+	
+	
+}

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -70,7 +70,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     	Preconditions.checkNotNull(newGraph);
     	boolean testComplete = true;
     	for (Alternative a : newGraph.nodes()) {
-    		if (testComplete == false)
+    		if (!testComplete)
     			throw new IllegalArgumentException("There are no edges between all alternatives");
     		if (newGraph.successors(a).size() == 0)
     			testComplete = false;

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -44,10 +44,13 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     	boolean testComplete = true;
     	for (Alternative a : prefGraph.nodes()) {
     		if (testComplete == false)
-    			throw new IllegalArgumentException("The preference is not complete");
-    		if (prefGraph.successors(a) == null)
+    			throw new IllegalArgumentException("There are no edges between all alternatives");
+    		if (prefGraph.successors(a).size() == 0)
     			testComplete = false;
     	}
+    	
+    	if (Graphs.hasCycle(prefGraph))
+			throw new IllegalArgumentException("The preference has a cycle");
     		
     	for (Alternative a1 : prefGraph.nodes()) {
             for (Alternative a2 : prefGraph.successors(a1)) {
@@ -82,6 +85,10 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 		LOGGER.debug("MutablePreferenceImpl addAlternative");
         Preconditions.checkNotNull(a);
         graph.addNode(a);
+        for (Alternative ai : graph.nodes()) {
+        	if (graph.successors(a).size() == 0)
+    			graph.putEdge(ai, a);
+    	}
 		
 	}
 

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -68,6 +68,26 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 	public void changeOrder(MutableGraph<Alternative> newGraph) {
     	LOGGER.debug("MutableLinearPreferenceImpl changeOrder");
     	Preconditions.checkNotNull(newGraph);
+    	boolean testComplete = true;
+    	for (Alternative a : newGraph.nodes()) {
+    		if (testComplete == false)
+    			throw new IllegalArgumentException("There are no edges between all alternatives");
+    		if (newGraph.successors(a).size() == 0)
+    			testComplete = false;
+    	}
+    	
+    	if (Graphs.hasCycle(newGraph))
+			throw new IllegalArgumentException("The preference has a cycle");
+    		
+    	for (Alternative a1 : newGraph.nodes()) {
+            for (Alternative a2 : newGraph.successors(a1)) {
+                if (Graphs.transitiveClosure(newGraph).hasEdgeConnecting(a2,
+                                a1) && !a2.equals(a1)) {
+                    throw new IllegalArgumentException("The alternatives " + a1
+                                    + " and " + a2 + " cannot be ex-eaquo.");
+                }
+            }
+        }
     	graph = newGraph;
     	alternatives = newGraph.nodes();
 	}

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -6,8 +6,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Graphs;
+import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 
 import io.github.oliviercailloux.j_voting.Alternative;
@@ -26,71 +28,65 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     private static final Logger LOGGER = LoggerFactory
             .getLogger(MutableLinearPreferenceImpl.class.getName());
     
-    private MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
+    public MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
     	this.voter = voter;
     	graph = prefGraph; 
     	alternatives = graph.nodes();
     }
 
+    //faire des constructeurs given ?? comme dans MutablePreference 
+    //et mettre le constructeur au dessus en private
     
     @Override
-	public Set<Alternative> changeOrder(Set<Alternative> alternatives) {
+	public Set<Alternative> changeOrder(Set<Alternative> a) {
 		
 		return null;
 	}
 
 	@Override
 	public void deleteAlternative(Alternative a) {
-		LOGGER.debug("MutablePreferenceImpl addAlternative");
+		
+		LOGGER.debug("MutableLinearPreferenceImpl addAlternative");
         Preconditions.checkNotNull(a);
         graph.removeNode(a);
 		
 	}
 	
 	@Override
-	public MutableGraph<Alternative> asMutableGraph() {
-		return graph;
-	}
-
-	@Override
-	public void addAlternative(Alternative alternative) {
-		
+	public void addAlternative(Alternative a) {
+		LOGGER.debug("MutablePreferenceImpl addAlternative");
+        Preconditions.checkNotNull(a);
+        graph.addNode(a);
 		
 	}
 
-	@Override
-	public void addEquivalence(Alternative a1, Alternative a2) {
-		
-		
-	}
-
-	@Override
-	public void setAsLeastAsGood(Alternative a1, Alternative a2) {
-		
-		
-	}
-
-	@Override
-	public Graph<Alternative> asGraph() {
-		return graph;
-		
-		
-	}
 
 	@Override
 	public Set<Alternative> getAlternatives() {
-		return alternatives;
 		
+		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");
+		
+		if (alternatives.size() != graph.nodes().size() || !(alternatives.containsAll(graph.nodes()))) {
+        	
+			throw new IllegalStateException("An alternative must not be deleted from the set");
+        }
+		
+		return ImmutableSet.copyOf(alternatives);
+        
 	}
+
 
 	@Override
 	public Voter getVoter() {
+		return voter;
+	}
 	
-		return null;
+	@Override
+	public Graph<Alternative> asGraph() {
+		return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
 	}
 
 	
-    
 	
    
 	

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -91,7 +91,11 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     	}
 		
 	}
-
+	
+	/**
+     * @return an immutable set of all alternatives of the preference
+     * 
+     */
 	@Override
 	public Set<Alternative> getAlternatives() {	
 		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");	

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -17,7 +17,7 @@ import io.github.oliviercailloux.j_voting.Voter;
 
 import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
 
-public class MutableLinearPreferenceImpl implements MutableLinearPreference{
+public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	
 	protected Voter voter;
     protected MutableGraph<Alternative> graph;
@@ -32,7 +32,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     }
     
     /**
-     * @param pref  is a mutable graph of alternatives representing the
+     * @param prefGraph is a mutable graph of alternatives representing the
      *              preference. This graph has no cycle.
      * @param voter is the Voter associated to the Preference.
      * @return the mutable linear preference
@@ -43,7 +43,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     	Preconditions.checkNotNull(prefGraph);
     	boolean testComplete = true;
     	for (Alternative a : prefGraph.nodes()) {
-    		if (testComplete == false)
+    		if (!testComplete)
     			throw new IllegalArgumentException("There are no edges between all alternatives");
     		if (prefGraph.successors(a).size() == 0)
     			testComplete = false;
@@ -76,8 +76,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 	public void deleteAlternative(Alternative a) {	
 		LOGGER.debug("MutableLinearPreferenceImpl deleteAlternative");
         Preconditions.checkNotNull(a);
-        graph.removeNode(a);
-		
+        graph.removeNode(a);	
 	}
 	
 	@Override
@@ -89,7 +88,6 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
         	if (graph.successors(a).size() == 0)
     			graph.putEdge(ai, a);
     	}
-		
 	}
 	
 	/**
@@ -113,11 +111,5 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 	@Override
 	public Graph<Alternative> asGraph() {
 		return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
-	}
-
-	
-	
-   
-	
-	
+	}	
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -14,7 +14,8 @@ import io.github.oliviercailloux.j_voting.Alternative;
 public interface MutableLinearPreference extends Preference {
 	
 	/**
-	 * Change the order of the alternatives. 
+	 * Change the order of the alternatives. Check if there is a cycle, if all the alternatives are comparable two-by-two
+	 * and if all alternatives are not equals.
 	 * 
 	 * @param newGraph to change the old preference to the new one with an alternative graph.
 	 */
@@ -29,8 +30,7 @@ public interface MutableLinearPreference extends Preference {
 	public void deleteAlternative(Alternative alternative);
 	
 	/**
-	 * Adds an alternative to the Preference. This alternative is not preferred to
-	 * any other of the preference, it is being added isolated.
+	 * Adds an alternative to the Preference. Add a link between the "weakest" alternatives and the new
 	 *
 	 * @param alternative to add to the preference.
 	 */

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -1,0 +1,18 @@
+package io.github.oliviercailloux.j_voting.preferences.interfaces;
+
+import java.util.Set;
+
+
+
+import io.github.oliviercailloux.j_voting.Alternative;
+
+public interface MutableLinearPreference extends MutablePreference{
+	
+	
+	//Méthode de changement de position des alternative
+	public Set<Alternative> changeOrder(Set<Alternative> alternative);
+	
+	//Méthode pour supprimer des alternatives
+	public void deleteAlternative(Alternative a);
+	
+}

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -1,6 +1,7 @@
 package io.github.oliviercailloux.j_voting.preferences.interfaces;
 
-import java.util.Set;
+import com.google.common.graph.MutableGraph;
+
 import io.github.oliviercailloux.j_voting.Alternative;
 
 /**
@@ -16,7 +17,7 @@ public interface MutableLinearPreference extends Preference{
 	 * Change the order of the alternatives
 	 * 
 	 */
-	public Set<Alternative> changeOrder(Set<Alternative> alternative);
+	public void changeOrder(MutableGraph<Alternative> newGraph);
 	
 	/**
 	 * Delete an alternative from the preference

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -24,4 +24,10 @@ public interface MutableLinearPreference extends Preference{
 	 */
 	public void deleteAlternative(Alternative a);
 	
+	/**
+	 * Add an alternative from the preference
+	 * 
+	 */
+	
+	public void addAlternative(Alternative a);
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -1,18 +1,27 @@
 package io.github.oliviercailloux.j_voting.preferences.interfaces;
 
 import java.util.Set;
-
-
-
 import io.github.oliviercailloux.j_voting.Alternative;
 
-public interface MutableLinearPreference extends MutablePreference{
+/**
+ * A mutable linear preference is a mutable antisymmetric complete preference. A mutable linear
+ * preference represents a linear order, or equivalently an antisymmetric
+ * complete order, or equivalently, the reduction of a weak-order.
+ * 
+ */
+
+public interface MutableLinearPreference extends Preference{
 	
-	
-	//Méthode de changement de position des alternative
+	/**
+	 * Change the order of the alternatives
+	 * 
+	 */
 	public Set<Alternative> changeOrder(Set<Alternative> alternative);
 	
-	//Méthode pour supprimer des alternatives
+	/**
+	 * Delete an alternative from the preference
+	 * 
+	 */
 	public void deleteAlternative(Alternative a);
 	
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -14,21 +14,26 @@ import io.github.oliviercailloux.j_voting.Alternative;
 public interface MutableLinearPreference extends Preference{
 	
 	/**
-	 * Change the order of the alternatives
+	 * Change the order of the alternatives. 
 	 * 
+	 * @param newGraph to change the old preference to the new one with an alternative graph.
 	 */
 	public void changeOrder(MutableGraph<Alternative> newGraph);
 	
 	/**
-	 * Delete an alternative from the preference
-	 * 
+	 * Remove an alternative to the Preference. This alternative is deleted as well 
+	 * as the links between it and the other alternatives.
+	 *
+	 * @param alternative to remove to the preference.
 	 */
-	public void deleteAlternative(Alternative a);
+	public void deleteAlternative(Alternative alternative);
 	
 	/**
-	 * Add an alternative from the preference
-	 * 
+	 * Adds an alternative to the Preference. This alternative is not preferred to
+	 * any other of the preference, it is being added isolated.
+	 *
+	 * @param alternative to add to the preference.
 	 */
 	
-	public void addAlternative(Alternative a);
+	public void addAlternative(Alternative alternative);
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -11,7 +11,7 @@ import io.github.oliviercailloux.j_voting.Alternative;
  * 
  */
 
-public interface MutableLinearPreference extends Preference{
+public interface MutableLinearPreference extends Preference {
 	
 	/**
 	 * Change the order of the alternatives. 

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -1,0 +1,83 @@
+package io.github.oliviercailloux.j_voting.preferences;
+
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a1;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a2;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a3;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a4;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a5;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.Graphs;
+import com.google.common.graph.MutableGraph;
+
+import io.github.oliviercailloux.j_voting.Alternative;
+import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.preferences.classes.MutableLinearPreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.MutablePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreference;
+
+public class MutableLinearPreferenceImplTest {
+	
+	@Test
+    void testAsGraph() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        graph.putEdge(a1, a2);
+        graph.putEdge(a3, a4);
+        graph.putEdge(a4, a5);
+        graph.putEdge(a5, a3);
+        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        graph.putEdge(a3, a3);
+        graph.putEdge(a4, a4);
+        graph.putEdge(a5, a5);
+        graph.putEdge(a3, a5);
+        graph.putEdge(a4, a3);
+        graph.putEdge(a5, a4);
+        assertEquals(graph, pref.asGraph());
+    }
+	
+
+	/**
+     * Tests whether the single alternative is added to the preferences' graph
+     */
+    @Test
+    void testAddAlternative() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        graph.putEdge(a1, a2);
+        graph.putEdge(a2, a1);
+        
+        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        graph.putEdge(a3, a3);
+        pref.addAlternative(a3);
+        assertEquals(graph, pref.asGraph());
+    }
+    
+    /**
+     * Tests whether the single alternative is removed to the preferences' graph
+     */
+	@Test
+    void testDeleteAlternative() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        
+        graph.putEdge(a1, a2);
+        graph.putEdge(a2, a1);
+        
+        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        pref.addAlternative(a3);
+        
+        pref.deleteAlternative(a3);
+        assertEquals(graph, pref.asGraph());
+    }
+}

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -1,6 +1,7 @@
 package io.github.oliviercailloux.j_voting.preferences;
 
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a1;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a12345;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a2;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a3;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a4;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableGraph;
@@ -22,34 +24,45 @@ import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreferen
 
 public class MutableLinearPreferenceImplTest {
 	
+	
+	
+	@Test
+    void testGiven() {
+		//Test du given mais pas obligatoire je pense 
+	}
+	/**
+     * Tests whether the preference is correctly expressed as a graph
+     */
 	@Test
     void testAsGraph() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(false).build();
+                        .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
-        graph.putEdge(a3, a4);
-        graph.putEdge(a4, a5);
-        graph.putEdge(a5, a3);
+        graph.putEdge(a2, a3);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a3, a5);
-        graph.putEdge(a4, a3);
-        graph.putEdge(a5, a4);
+        
+        graph.putEdge(a1,a1);
+        graph.putEdge(a2,a2);
+        graph.putEdge(a3,a3);
+        
+        graph.putEdge(a1,a3);
+        
         assertEquals(graph, pref.asGraph());
     }
 	
-
 	/**
      * Tests whether the single alternative is added to the preferences' graph
      */
     @Test
     void testAddAlternative() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(false).build();
+                        .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
-        
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-//        graph.putEdge(a3, a1);
-//        pref.addAlternative(a3);
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        graph.putEdge(a3, a3);
+        pref.addAlternative(a3);
         assertEquals(graph, pref.asGraph());
     }
     
@@ -62,14 +75,35 @@ public class MutableLinearPreferenceImplTest {
                         .allowsSelfLoops(true).build();
         
         graph.putEdge(a1, a2);
-        graph.putEdge(a2, a1);
-        
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         graph.putEdge(a1, a1);
         graph.putEdge(a2, a2);
         pref.addAlternative(a3);
-        
         pref.deleteAlternative(a3);
         assertEquals(graph, pref.asGraph());
+    }
+	
+	@Test
+    void testChangeOrder() {
+	
+		//a toi de jouer Léo
+		
+		
+	}
+	
+	 /**
+     * Tests whether method getAlternatives returns a set with all the
+     * alternatives of the preference
+     */
+    @Test
+    void testGetAlternatives() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        graph.putEdge(a1, a2);
+        graph.putEdge(a3, a4);
+        graph.putEdge(a5, a5);
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
+        ImmutableSet<Alternative> expected = a12345;
+        assertEquals(expected, pref.getAlternatives());
     }
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -18,9 +18,7 @@ import com.google.common.graph.MutableGraph;
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.preferences.classes.MutableLinearPreferenceImpl;
-import io.github.oliviercailloux.j_voting.preferences.classes.MutablePreferenceImpl;
 import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
-import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreference;
 
 public class MutableLinearPreferenceImplTest {
 	
@@ -28,7 +26,7 @@ public class MutableLinearPreferenceImplTest {
 	
 	@Test
     void testGiven() {
-		//Test du given mais pas obligatoire je pense 
+		//Optional
 	}
 	/**
      * Tests whether the preference is correctly expressed as a graph
@@ -41,13 +39,9 @@ public class MutableLinearPreferenceImplTest {
         graph.putEdge(a2, a3);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         
-        graph.putEdge(a1,a1);
-        graph.putEdge(a2,a2);
-        graph.putEdge(a3,a3);
-        
         graph.putEdge(a1,a3);
         
-        assertEquals(graph, pref.asGraph());
+        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
 	
 	/**
@@ -58,12 +52,11 @@ public class MutableLinearPreferenceImplTest {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
                         .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
+        graph.putEdge(a2, a3);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
-        graph.putEdge(a3, a3);
-        pref.addAlternative(a3);
-        assertEquals(graph, pref.asGraph());
+        pref.addAlternative(a4);
+        graph.putEdge(a3, a4);
+        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
     
     /**
@@ -76,19 +69,28 @@ public class MutableLinearPreferenceImplTest {
         
         graph.putEdge(a1, a2);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
         pref.addAlternative(a3);
         pref.deleteAlternative(a3);
-        assertEquals(graph, pref.asGraph());
+        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
 	
 	@Test
     void testChangeOrder() {
 	
-		//a toi de jouer Léo
+		MutableGraph<Alternative> graph1 = GraphBuilder.directed()
+                .allowsSelfLoops(true).build();
+		MutableGraph<Alternative> graph2 = GraphBuilder.directed()
+                .allowsSelfLoops(true).build();
+
+		graph1.putEdge(a1, a2);
+		graph1.putEdge(a2, a3);
 		
+		graph2.putEdge(a3, a2);
+		graph2.putEdge(a2, a1);
 		
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph1));
+		pref.changeOrder(graph2);
+		assertEquals(Graphs.transitiveClosure(graph2), pref.asGraph());	
 	}
 	
 	 /**
@@ -100,8 +102,9 @@ public class MutableLinearPreferenceImplTest {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
                         .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
+        graph.putEdge(a2, a3);
         graph.putEdge(a3, a4);
-        graph.putEdge(a5, a5);
+        graph.putEdge(a4, a5);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         ImmutableSet<Alternative> expected = a12345;
         assertEquals(expected, pref.getAlternatives());

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -25,17 +25,12 @@ public class MutableLinearPreferenceImplTest {
 	@Test
     void testAsGraph() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+                        .allowsSelfLoops(false).build();
         graph.putEdge(a1, a2);
         graph.putEdge(a3, a4);
         graph.putEdge(a4, a5);
         graph.putEdge(a5, a3);
-        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
-        graph.putEdge(a3, a3);
-        graph.putEdge(a4, a4);
-        graph.putEdge(a5, a5);
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         graph.putEdge(a3, a5);
         graph.putEdge(a4, a3);
         graph.putEdge(a5, a4);
@@ -49,15 +44,12 @@ public class MutableLinearPreferenceImplTest {
     @Test
     void testAddAlternative() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+                        .allowsSelfLoops(false).build();
         graph.putEdge(a1, a2);
-        graph.putEdge(a2, a1);
         
-        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
-        graph.putEdge(a3, a3);
-        pref.addAlternative(a3);
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
+//        graph.putEdge(a3, a1);
+//        pref.addAlternative(a3);
         assertEquals(graph, pref.asGraph());
     }
     
@@ -72,7 +64,7 @@ public class MutableLinearPreferenceImplTest {
         graph.putEdge(a1, a2);
         graph.putEdge(a2, a1);
         
-        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         graph.putEdge(a1, a1);
         graph.putEdge(a2, a2);
         pref.addAlternative(a3);

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -22,12 +22,6 @@ import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPr
 
 public class MutableLinearPreferenceImplTest {
 	
-	
-	
-	@Test
-    void testGiven() {
-		//Optional
-	}
 	/**
      * Tests whether the preference is correctly expressed as a graph
      */
@@ -74,6 +68,9 @@ public class MutableLinearPreferenceImplTest {
         assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
 	
+	/**
+     * Tests of the changeOrder method which returns the new preference well
+     */
 	@Test
     void testChangeOrder() {
 	

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -1,4 +1,4 @@
-package io.github.oliviercailloux.j_voting.preferences;
+package io.github.oliviercailloux.j_voting.preferences.classes;
 
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a1;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a12345;


### PR DESCRIPTION
Pierre&Leo

Our goal on this iteration is to create a MutableLinearPreferenceImpl class and the interface which implements MutableLinearPreference. This class aims to work on mutable and linear preferences. The number of alternatives can thus evolve, one alternative cannot be equal to another and all the alternatives are comparable two by two.

To do this, we have implemented several methods in this class :

- Constructor: Takes as parameters, a voter and a graph of alternatives. Verifies that this graph has no cycle, that each alternative is comparable two by two and that the alternatives are not equal. This returns a MutableLinearPreference.

- changeOrder method: Replaces the old graph with the one taken as parameter. This method verifies that this network has no cycle, that all alternatives are comparable two by two and that the alternatives are not equal.

- deleteAlternative method: Takes the alternative to be deleted as a parameter and deletes this alternative with its dependencies.

- addAlternative method : Adds the alternative provided as parameter. Also adds a link between the "lowest" ranked alternative and the new alternative.

- getAlternatives method: Returns an immutable set of preference alternatives.

- getVoter method : Returns a voter.

- asGraph method: Returns the transitive closure of this mutable and linear graph.

We also tested these different methods in a class of tests called MutableLinearPreferenceImplTest :
- testAsGraph()
- testAddAlternative()
- testDeleteAlternative()
- testChangeOrder()
- testGetAlternatives()