### PR TITLE
Replace old

### DIFF
--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/LinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/LinearPreferenceImpl.java
@@ -35,7 +35,7 @@ public class LinearPreferenceImpl extends CompletePreferenceImpl
      * @throws EmptySetException
      * @throws DuplicateValueException
      */
-    public static LinearPreferenceImpl asLinearPreference(Voter voter,
+    public static LinearPreference asLinearPreference(Voter voter,
                     List<Alternative> listAlternatives)
                     throws EmptySetException, DuplicateValueException {
         LOGGER.debug("LinearPreferenceImpl Factory with list of Alternatives");

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/LinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/LinearPreferenceImpl.java
@@ -35,7 +35,7 @@ public class LinearPreferenceImpl extends CompletePreferenceImpl
      * @throws EmptySetException
      * @throws DuplicateValueException
      */
-    public static LinearPreference asLinearPreference(Voter voter,
+    public static LinearPreferenceImpl asLinearPreference(Voter voter,
                     List<Alternative> listAlternatives)
                     throws EmptySetException, DuplicateValueException {
         LOGGER.debug("LinearPreferenceImpl Factory with list of Alternatives");

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfile.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 
 /**
@@ -27,22 +27,21 @@ public class ImmutableProfile extends ImmutableProfileI implements Profile {
      * @return new ImmutableProfile
      */
     public static ImmutableProfile createImmutableProfile(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> votes) {
+                    Map<Voter, ? extends CompletePreferenceImpl> votes) {
         LOGGER.debug("Factory ImmutableProfile");
         Preconditions.checkNotNull(votes);
         return new ImmutableProfile(votes);
     }
 
     private ImmutableProfile(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> votes) {
+                    Map<Voter, ? extends CompletePreferenceImpl> votes) {
         super(checkCompleteMap(votes));
     }
 
     @Override
     public Set<Alternative> getAlternatives() {
         LOGGER.debug("getAlternatives:");
-        OldCompletePreferenceImpl p = votes.values().iterator().next();
-        return OldCompletePreferenceImpl
-                        .toAlternativeSet(p.getPreferencesNonStrict());
+        CompletePreferenceImpl p = votes.values().iterator().next();
+        return p.getAlternatives();
     }
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
@@ -18,6 +18,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import io.github.oliviercailloux.j_voting.profiles.management.ProfileBuilder;
 
 /**
@@ -36,7 +38,7 @@ public class ImmutableProfileI implements ProfileI {
     }
 
     @Override
-    public CompletePreferenceImpl getPreference(Voter v) {
+    public CompletePreferenceImpl getPreference(Voter v) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("getPreference:");
         checkNotNull(v);
         LOGGER.debug("parameter voter : {}", v);

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
@@ -10,13 +10,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.management.ProfileBuilder;
 
@@ -27,16 +27,16 @@ public class ImmutableProfileI implements ProfileI {
 
     private static final Logger LOGGER = LoggerFactory
                     .getLogger(ImmutableProfileI.class.getName());
-    protected Map<Voter, ? extends OldCompletePreferenceImpl> votes;
+    protected Map<Voter, ? extends CompletePreferenceImpl> votes;
 
     protected ImmutableProfileI(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> votes) {
+                    Map<Voter, ? extends CompletePreferenceImpl> votes) {
         LOGGER.debug("ImmutableProfileI constructor");
         this.votes = votes;
     }
 
     @Override
-    public OldCompletePreferenceImpl getPreference(Voter v) {
+    public CompletePreferenceImpl getPreference(Voter v) {
         LOGGER.debug("getPreference:");
         checkNotNull(v);
         LOGGER.debug("parameter voter : {}", v);
@@ -50,10 +50,11 @@ public class ImmutableProfileI implements ProfileI {
     public int getMaxSizeOfPreference() {
         LOGGER.debug("getMaxSizeOfPreference");
         int maxSize = 0;
-        Collection<? extends OldCompletePreferenceImpl> pref = votes.values();
-        for (OldCompletePreferenceImpl p : pref) {
-            if (maxSize < p.size()) {
-                maxSize = p.size();
+        Collection<? extends CompletePreferenceImpl> pref = votes.values();
+        System.out.println(votes.values());
+        for (CompletePreferenceImpl p : pref) {
+            if (maxSize < p.getAlternatives().size()) {
+                maxSize = p.getAlternatives().size();
             }
         }
         LOGGER.debug("biggest Preference has size : {}", maxSize);
@@ -61,7 +62,7 @@ public class ImmutableProfileI implements ProfileI {
     }
 
     @Override
-    public Map<Voter, ? extends OldCompletePreferenceImpl> getProfile() {
+    public Map<Voter, ? extends CompletePreferenceImpl> getProfile() {
         LOGGER.debug("getProfile:");
         return votes;
     }
@@ -90,10 +91,10 @@ public class ImmutableProfileI implements ProfileI {
     }
 
     @Override
-    public Set<OldCompletePreferenceImpl> getUniquePreferences() {
+    public Set<CompletePreferenceImpl> getUniquePreferences() {
         LOGGER.debug("getUniquePreferences");
-        Set<OldCompletePreferenceImpl> unique = new LinkedHashSet<>();
-        for (OldCompletePreferenceImpl pref : votes.values()) {
+        Set<CompletePreferenceImpl> unique = new LinkedHashSet<>();
+        for (CompletePreferenceImpl pref : votes.values()) {
             LOGGER.debug("next preference : {}", pref);
             unique.add(pref);
         }
@@ -109,10 +110,10 @@ public class ImmutableProfileI implements ProfileI {
     @Override
     public boolean isComplete() {
         LOGGER.debug("isComplete");
-        OldCompletePreferenceImpl pref = votes.values().iterator().next();
+        CompletePreferenceImpl pref = votes.values().iterator().next();
         LOGGER.debug("first preferences :{}", pref);
-        for (OldCompletePreferenceImpl p : votes.values()) {
-            if (!p.hasSameAlternatives(pref)) {
+        for (CompletePreferenceImpl p : votes.values()) {
+            if (!p.getAlternatives().equals(pref.getAlternatives())) {
                 LOGGER.debug("Profile incomplete.");
                 return false;
             }
@@ -124,7 +125,7 @@ public class ImmutableProfileI implements ProfileI {
     @Override
     public boolean isStrict() {
         LOGGER.debug("isStrict:");
-        for (OldCompletePreferenceImpl p : votes.values()) {
+        for (CompletePreferenceImpl p : votes.values()) {
             if (!p.isStrict()) {
                 LOGGER.debug("non strict");
                 return false;
@@ -135,12 +136,12 @@ public class ImmutableProfileI implements ProfileI {
     }
 
     @Override
-    public int getNbVoterForPreference(OldCompletePreferenceImpl p) {
+    public int getNbVoterForPreference(CompletePreferenceImpl p) {
         LOGGER.debug("getnbVoterByPreference:");
         checkNotNull(p);
         LOGGER.debug("parameter preference: {}", p);
         int nb = 0;
-        for (OldCompletePreferenceImpl p1 : votes.values()) {
+        for (CompletePreferenceImpl p1 : votes.values()) {
             if (p.equals(p1)) {
                 nb++;
             }
@@ -192,8 +193,8 @@ public class ImmutableProfileI implements ProfileI {
      * @return the map if and only if it represents a complete profile. If it is
      *         incomplete, it throws an IllegalArgumentException.
      */
-    public static Map<Voter, ? extends OldCompletePreferenceImpl> checkCompleteMap(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> map) {
+    public static Map<Voter, ? extends CompletePreferenceImpl> checkCompleteMap(
+                    Map<Voter, ? extends CompletePreferenceImpl> map) {
         LOGGER.debug("checkCompleteMap:");
         checkNotNull(map);
         if (!createImmutableProfileI(map).isComplete()) {
@@ -208,8 +209,8 @@ public class ImmutableProfileI implements ProfileI {
      * @return the map if and only if it represents a strict profile. If it is
      *         not strict, it throws an IllegalArgumentException.
      */
-    public static Map<Voter, ? extends OldCompletePreferenceImpl> checkStrictMap(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> map) {
+    public static Map<Voter, ? extends CompletePreferenceImpl> checkStrictMap(
+                    Map<Voter, ? extends CompletePreferenceImpl> map) {
         LOGGER.debug("checkstrictMap:");
         checkNotNull(map);
         if (!createImmutableProfileI(map).isStrict()) {
@@ -225,7 +226,7 @@ public class ImmutableProfileI implements ProfileI {
      * @return new ImmutableProfileI
      */
     public static ImmutableProfileI createImmutableProfileI(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> votes) {
+                    Map<Voter, ? extends CompletePreferenceImpl> votes) {
         LOGGER.debug("Factory ImmutableProfileI");
         checkNotNull(votes);
         return new ImmutableProfileI(votes);
@@ -241,9 +242,8 @@ public class ImmutableProfileI implements ProfileI {
     public Set<Alternative> getAlternatives() {
         LOGGER.debug("getAlternatives");
         Set<Alternative> set = new HashSet<>();
-        for (OldCompletePreferenceImpl pref : getUniquePreferences()) {
-            for (Alternative a : OldCompletePreferenceImpl
-                            .toAlternativeSet(pref.getPreferencesNonStrict())) {
+        for (CompletePreferenceImpl pref : getUniquePreferences()) {
+            for (Alternative a : pref.getAlternatives()) {
                 set.add(a);
             }
         }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
@@ -13,7 +13,7 @@ import java.util.TreeSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
@@ -38,7 +38,7 @@ public class ImmutableProfileI implements ProfileI {
     @Override
     public OldCompletePreferenceImpl getPreference(Voter v) {
         LOGGER.debug("getPreference:");
-        Preconditions.checkNotNull(v);
+        checkNotNull(v);
         LOGGER.debug("parameter voter : {}", v);
         if (votes.containsKey(v)) {
             return votes.get(v);
@@ -137,7 +137,7 @@ public class ImmutableProfileI implements ProfileI {
     @Override
     public int getNbVoterForPreference(OldCompletePreferenceImpl p) {
         LOGGER.debug("getnbVoterByPreference:");
-        Preconditions.checkNotNull(p);
+        checkNotNull(p);
         LOGGER.debug("parameter preference: {}", p);
         int nb = 0;
         for (OldCompletePreferenceImpl p1 : votes.values()) {
@@ -195,7 +195,7 @@ public class ImmutableProfileI implements ProfileI {
     public static Map<Voter, ? extends OldCompletePreferenceImpl> checkCompleteMap(
                     Map<Voter, ? extends OldCompletePreferenceImpl> map) {
         LOGGER.debug("checkCompleteMap:");
-        Preconditions.checkNotNull(map);
+        checkNotNull(map);
         if (!createImmutableProfileI(map).isComplete()) {
             throw new IllegalArgumentException("map is incomplete");
         }
@@ -211,7 +211,7 @@ public class ImmutableProfileI implements ProfileI {
     public static Map<Voter, ? extends OldCompletePreferenceImpl> checkStrictMap(
                     Map<Voter, ? extends OldCompletePreferenceImpl> map) {
         LOGGER.debug("checkstrictMap:");
-        Preconditions.checkNotNull(map);
+        checkNotNull(map);
         if (!createImmutableProfileI(map).isStrict()) {
             throw new IllegalArgumentException("map is not strict");
         }
@@ -227,7 +227,7 @@ public class ImmutableProfileI implements ProfileI {
     public static ImmutableProfileI createImmutableProfileI(
                     Map<Voter, ? extends OldCompletePreferenceImpl> votes) {
         LOGGER.debug("Factory ImmutableProfileI");
-        Preconditions.checkNotNull(votes);
+        checkNotNull(votes);
         return new ImmutableProfileI(votes);
     }
 

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileI.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,10 +95,12 @@ public class ImmutableProfileI implements ProfileI {
     @Override
     public Set<CompletePreferenceImpl> getUniquePreferences() {
         LOGGER.debug("getUniquePreferences");
+        Set<ImmutableList<ImmutableSet<Alternative>>> eqClassesSet = new LinkedHashSet<>();
         Set<CompletePreferenceImpl> unique = new LinkedHashSet<>();
         for (CompletePreferenceImpl pref : votes.values()) {
-            LOGGER.debug("next preference : {}", pref);
-            unique.add(pref);
+            if(eqClassesSet.add(pref.asEquivalenceClasses())) {
+                unique.add(pref);
+            }
         }
         return unique;
     }
@@ -142,7 +146,7 @@ public class ImmutableProfileI implements ProfileI {
         LOGGER.debug("parameter preference: {}", p);
         int nb = 0;
         for (CompletePreferenceImpl p1 : votes.values()) {
-            if (p.equals(p1)) {
+            if (p.asEquivalenceClasses().equals(p1.asEquivalenceClasses())) {
                 nb++;
             }
         }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
@@ -79,7 +79,7 @@ public class ImmutableStrictProfile extends ImmutableStrictProfileI
 
     /**
      * Get a List of each ith Alternative of each unique Preference in the
-     * profile
+     * profilet
      * 
      * @param i not <code> null</code> the rank of the Alternatives to get
      * @return a List of Alternatives

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
@@ -17,8 +17,12 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
+//import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
+
 
 /**
  * This class is immutable. Represents a Strict Complete Profile.
@@ -30,11 +34,11 @@ public class ImmutableStrictProfile extends ImmutableStrictProfileI
                     .getLogger(ImmutableStrictProfile.class.getName());
 
     public static ImmutableStrictProfile createImmutableStrictProfile(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> map) {
+                    Map<Voter, ? extends CompletePreferenceImpl> map) {
         return new ImmutableStrictProfile(map);
     }
 
-    private ImmutableStrictProfile(Map<Voter, ? extends OldCompletePreferenceImpl> map) {
+    private ImmutableStrictProfile(Map<Voter, ? extends CompletePreferenceImpl> map) {
         super(checkCompleteMap(map));
     }
 
@@ -47,8 +51,8 @@ public class ImmutableStrictProfile extends ImmutableStrictProfileI
     @Override
     public Set<Alternative> getAlternatives() {
         LOGGER.debug("getAlternatives :");
-        OldCompletePreferenceImpl p = votes.values().iterator().next();
-        return OldCompletePreferenceImpl.toAlternativeSet(p.getPreferencesNonStrict());
+        CompletePreferenceImpl p = votes.values().iterator().next();
+        return p.getAlternatives();
     }
 
     /**
@@ -64,7 +68,7 @@ public class ImmutableStrictProfile extends ImmutableStrictProfileI
         NavigableSet<Voter> voters = getAllVoters();
         List<Alternative> listIthAlternatives = new ArrayList<>();
         for (Voter v : voters) {
-            listIthAlternatives.add(getPreference(v).getAlternative(i));
+            listIthAlternatives.add(getPreference(v).asList().get(i));
         }
         return listIthAlternatives;
     }
@@ -81,8 +85,9 @@ public class ImmutableStrictProfile extends ImmutableStrictProfileI
         LOGGER.debug("getIthAlternativesOfUniquePreferences :");
         Preconditions.checkNotNull(i);
         List<Alternative> listIthAlternatives = new ArrayList<>();
-        for (OldCompletePreferenceImpl p : getUniquePreferences()) {
-            listIthAlternatives.add(p.getAlternative(i));
+        for (CompletePreferenceImpl p : getUniquePreferences()) {
+        	OldLinearPreferenceImpl l = p.toStrictPreference();
+            listIthAlternatives.add(l.getAlternative(i));
         }
         return listIthAlternatives;
     }
@@ -100,10 +105,9 @@ public class ImmutableStrictProfile extends ImmutableStrictProfileI
             }
             soc.append(getNbVoters() + "," + getSumVoteCount() + ","
                             + getNbUniquePreferences() + "\n");
-            for (OldCompletePreferenceImpl pref : this.getUniquePreferences()) {
+            for (CompletePreferenceImpl pref : this.getUniquePreferences()) {
                 soc.append(getNbVoterForPreference(pref));
-                for (Alternative a : OldCompletePreferenceImpl.toAlternativeSet(
-                                pref.getPreferencesNonStrict())) {
+                for (Alternative a : pref.getAlternatives()) {
                     soc.append("," + a);
                 }
                 soc.append("\n");

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
@@ -20,6 +20,8 @@ import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 //import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 
@@ -60,9 +62,11 @@ public class ImmutableStrictProfile extends ImmutableStrictProfileI
      * 
      * @param i not <code> null</code> the rank of the Alternatives to get
      * @return a List of Alternatives
+     * @throws DuplicateValueException 
+     * @throws EmptySetException 
      */
     @Override
-    public List<Alternative> getIthAlternatives(int i) {
+    public List<Alternative> getIthAlternatives(int i) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("getIthAlternatives :");
         Preconditions.checkNotNull(i);
         NavigableSet<Voter> voters = getAllVoters();

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfile.java
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
-//import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
 import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileI.java
@@ -117,10 +117,12 @@ public class ImmutableStrictProfileI extends ImmutableProfileI
                             + getNbUniquePreferences() + "\n");
             for (CompletePreferenceImpl pref : this.getUniquePreferences()) {
                 soi.append(getNbVoterForPreference(pref));
+                for (Alternative a : pref.getAlternatives()) {
                     soi.append("," + a);
                 }
                 soi.append("\n");
             }
             writer.append(soi);
         }
+    }
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileI.java
@@ -16,9 +16,13 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+//import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 
 /**
  * This class is immutable. Represents a Strict Incomplete Profile.
@@ -36,46 +40,47 @@ public class ImmutableStrictProfileI extends ImmutableProfileI
      * @return new ImmutableStrictProfileI
      */
     public static ImmutableStrictProfileI createImmutableStrictProfileI(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> map) {
+                    Map<Voter, ? extends CompletePreferenceImpl> map) {
         LOGGER.debug("Factory ImmutableStrictProfileI");
         checkStrictMap(map);
         return new ImmutableStrictProfileI(map);
     }
 
     protected ImmutableStrictProfileI(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> map) {
+                    Map<Voter, ? extends CompletePreferenceImpl> map) {
         super(map);
         LOGGER.debug("ImmutableStrictProfileI  constructor");
     }
 
     @Override
-    public OldLinearPreferenceImpl getPreference(Voter v) {
+    public LinearPreferenceImpl getPreference(Voter v) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("getPreference:");
         Preconditions.checkNotNull(v);
         if (!votes.containsKey(v)) {
             throw new NoSuchElementException(
                             "Voter " + v + "is not in the map !");
         }
-        return votes.get(v).toStrictPreference();
+        return (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v, votes.get(v).getAlternatives().asList());
     }
 
     @Override
-    public List<String> getIthAlternativesAsStrings(int i) {
+    public List<String> getIthAlternativesAsStrings(int i) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("getIthAlternativesStrings");
         if (i > getMaxSizeOfPreference()) {
             throw new IndexOutOfBoundsException(
                             "The given index is out of bound.");
         }
+        
         List<String> list = new ArrayList<>();
         for (Voter v : getAllVoters()) {
-            OldLinearPreferenceImpl p = getPreference(v);
+            LinearPreferenceImpl p = getPreference(v);
             LOGGER.debug("the voter {} votes for the preference {}", v, p);
-            if (i >= p.size()) {
+            if (i >= p.asList().size()) {
                 list.add("");
                 LOGGER.debug("the preference is smaller than the given index");
             } else {
-                list.add(p.getAlternative(i).toString());
-                LOGGER.debug("the ith alternative is {}", p.getAlternative(i));
+                list.add(p.asList().get(i).toString());
+                LOGGER.debug("the ith alternative is {}", p.asList().get(i));
             }
         }
         return list;
@@ -86,11 +91,11 @@ public class ImmutableStrictProfileI extends ImmutableProfileI
         LOGGER.debug("getIthAlternativesOfUniquePrefAsString");
         Preconditions.checkNotNull(i);
         List<String> list = new ArrayList<>();
-        for (OldCompletePreferenceImpl p : getUniquePreferences()) {
+        for (CompletePreferenceImpl p : getUniquePreferences()) {
             String alter = "";
-            if (i < p.size()) {
-                alter = p.getAlternative(i).toString();
-                LOGGER.debug("the ith alternative is {}", p.getAlternative(i));
+            if (i < p.asEquivalenceClasses().size()) {
+                alter = p.getAlternatives(i).toString();
+                LOGGER.debug("the ith alternative is {}", p.getAlternatives(i));
             }
             list.add(alter);
         }
@@ -110,10 +115,8 @@ public class ImmutableStrictProfileI extends ImmutableProfileI
             }
             soi.append(getNbVoters() + "," + getSumVoteCount() + ","
                             + getNbUniquePreferences() + "\n");
-            for (OldCompletePreferenceImpl pref : this.getUniquePreferences()) {
+            for (CompletePreferenceImpl pref : this.getUniquePreferences()) {
                 soi.append(getNbVoterForPreference(pref));
-                for (Alternative a : OldCompletePreferenceImpl.toAlternativeSet(
-                                pref.getPreferencesNonStrict())) {
                     soi.append("," + a);
                 }
                 soi.append("\n");
@@ -121,4 +124,3 @@ public class ImmutableStrictProfileI extends ImmutableProfileI
             writer.append(soi);
         }
     }
-}

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ProfileI.java
@@ -5,7 +5,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 
 /**
@@ -20,7 +20,7 @@ public interface ProfileI {
      * @param v a voter not <code>null</code>
      * @return the preference of the voter v in the profile.
      */
-    public OldCompletePreferenceImpl getPreference(Voter v);
+    public CompletePreferenceImpl getPreference(Voter v);
 
     /**
      * @return the maximum size of a Preference in an incomplete Profile
@@ -31,7 +31,7 @@ public interface ProfileI {
      * 
      * @return the profile as a map mapping the voters to their preference.
      */
-    public Map<Voter, ? extends OldCompletePreferenceImpl> getProfile();
+    public Map<Voter, ? extends CompletePreferenceImpl> getProfile();
 
     /**
      * 
@@ -56,7 +56,7 @@ public interface ProfileI {
      * 
      * @return a set of all the different preferences in the profile.
      */
-    public Set<OldCompletePreferenceImpl> getUniquePreferences();
+    public Set<CompletePreferenceImpl> getUniquePreferences();
 
     /**
      * 
@@ -83,7 +83,7 @@ public interface ProfileI {
      * @param p a Preference not <code >null </code>
      * @return the number of voters that voted for p.
      */
-    public int getNbVoterForPreference(OldCompletePreferenceImpl p);
+    public int getNbVoterForPreference(CompletePreferenceImpl p);
 
     /**
      * 

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/ProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/ProfileI.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 
 /**
  * A ProfileI represents an incomplete profile. The preferences can be strict or
@@ -20,7 +22,7 @@ public interface ProfileI {
      * @param v a voter not <code>null</code>
      * @return the preference of the voter v in the profile.
      */
-    public CompletePreferenceImpl getPreference(Voter v);
+    public CompletePreferenceImpl getPreference(Voter v)throws EmptySetException, DuplicateValueException;
 
     /**
      * @return the maximum size of a Preference in an incomplete Profile

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/StrictProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/StrictProfile.java
@@ -5,6 +5,8 @@ import java.io.OutputStream;
 import java.util.List;
 
 import io.github.oliviercailloux.j_voting.Alternative;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 
 /**
  * A StrictProfile represents a complete StrictProfile. The preferences are
@@ -18,7 +20,7 @@ public interface StrictProfile extends StrictProfileI, Profile {
      *          the profile
      * @return a List of Alternatives
      */
-    public List<Alternative> getIthAlternatives(int i);
+    public List<Alternative> getIthAlternatives(int i) throws EmptySetException, DuplicateValueException;
 
     /**
      * @param i not <code>null</code> the ith alternative to get from Voters

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/StrictProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/StrictProfileI.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 
 /**
@@ -21,7 +23,7 @@ public interface StrictProfileI extends ProfileI {
      * @return the StrictPreference of the voter v in the profile.
      */
     @Override
-    public LinearPreferenceImpl getPreference(Voter v);
+    public LinearPreferenceImpl getPreference(Voter v)throws EmptySetException, DuplicateValueException;
 
     @Override
     public default boolean isStrict() {
@@ -35,7 +37,7 @@ public interface StrictProfileI extends ProfileI {
      *         If the preference doesn't have an ith alternative, it adds an
      *         empty string to the list.
      */
-    public List<String> getIthAlternativesAsStrings(int i);
+    public List<String> getIthAlternativesAsStrings(int i) throws EmptySetException, DuplicateValueException;
 
     /**
      * 

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/StrictProfileI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/StrictProfileI.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 
 /**
  * A StrictProfileI represents an incomplete StrictProfile. The preferences are
@@ -20,7 +21,7 @@ public interface StrictProfileI extends ProfileI {
      * @return the StrictPreference of the voter v in the profile.
      */
     @Override
-    public OldLinearPreferenceImpl getPreference(Voter v);
+    public LinearPreferenceImpl getPreference(Voter v);
 
     @Override
     public default boolean isStrict() {

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/Borda.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/Borda.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +16,7 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableProfileI;
 import io.github.oliviercailloux.j_voting.profiles.ProfileI;
@@ -65,8 +67,8 @@ public class Borda implements SocialWelfareFunction {
      * @return a Preference with the alternatives sorted
      */
     @Override
-    public OldCompletePreferenceImpl getSocietyPreference(
-                    ImmutableProfileI profile) {
+    public CompletePreferenceImpl getSocietyPreference(
+                    ImmutableProfileI profile) throws DuplicateValueException, EmptySetException {
         LOGGER.debug("getSocietyStrictPreference");
         Preconditions.checkNotNull(profile);
         LOGGER.debug("parameter SProfile : {}", profile);
@@ -82,8 +84,9 @@ public class Borda implements SocialWelfareFunction {
                 tempscores.remove(a, tempscores.count(a));
             }
         }
-        OldCompletePreferenceImpl pref = OldCompletePreferenceImpl
-                        .createCompletePreferenceImpl(al);
+        Voter society = Voter.createVoter(1);
+        CompletePreferenceImpl pref = (CompletePreferenceImpl) CompletePreferenceImpl
+                        .asCompletePreference(society, al);
         LOGGER.debug("return AScores : {}", pref);
         return pref;
     }
@@ -95,14 +98,13 @@ public class Borda implements SocialWelfareFunction {
      *              the preference to the multiset for the alternatives in this
      *              StrictPreference
      */
-    public void setScores(OldCompletePreferenceImpl pref) {
+    public void setScores(CompletePreferenceImpl pref) {
         LOGGER.debug("getScorePref");
         Preconditions.checkNotNull(pref);
         LOGGER.debug("parameter SPref : {}", pref);
-        int size = pref.getPreferencesNonStrict().size();
-        for (Alternative a : OldCompletePreferenceImpl
-                        .toAlternativeSet(pref.getPreferencesNonStrict())) {
-            scores.add(a, size - pref.getAlternativeRank(a) + 1);
+        int size = pref.asEquivalenceClasses().size();
+        for (Alternative a : pref.getAlternatives()) {
+            scores.add(a, size - pref.getRank(a) + 1);
         }
         LOGGER.debug("return score : {}", scores);
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/Borda.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/Borda.java
@@ -65,10 +65,11 @@ public class Borda implements SocialWelfareFunction {
     /**
      * @param profile a ProfileI <code>not null</code>
      * @return a Preference with the alternatives sorted
+     * @throws Exception 
      */
     @Override
     public CompletePreferenceImpl getSocietyPreference(
-                    ImmutableProfileI profile) throws DuplicateValueException, EmptySetException {
+                    ImmutableProfileI profile) throws Exception {
         LOGGER.debug("getSocietyStrictPreference");
         Preconditions.checkNotNull(profile);
         LOGGER.debug("parameter SProfile : {}", profile);
@@ -115,7 +116,7 @@ public class Borda implements SocialWelfareFunction {
      *                multiset for the profile (if an alternative has a score of
      *                3, it ill appear three times in the multiset)
      */
-    public void setScores(ProfileI profile) {
+    public void setScores(ProfileI profile) throws Exception {
         LOGGER.debug("getScoreProf");
         Preconditions.checkNotNull(profile);
         LOGGER.debug("parameter SProfile : {}", profile);

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/Dictator.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/Dictator.java
@@ -7,8 +7,10 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableProfileI;
 
 /**
@@ -42,10 +44,11 @@ public class Dictator implements SocialWelfareFunction {
      * 
      * @param profile
      * @return the dictator's preference
+     * @throws Exception 
      */
     @Override
-    public OldCompletePreferenceImpl getSocietyPreference(
-                    ImmutableProfileI profile) {
+    public CompletePreferenceImpl getSocietyPreference(
+                    ImmutableProfileI profile) throws Exception {
         LOGGER.debug("getSocietyStrictPreference");
         Preconditions.checkNotNull(profile);
         Preconditions.checkArgument(profile.getProfile().containsKey(dictator));

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/OldFrenchElection.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/OldFrenchElection.java
@@ -5,7 +5,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableProfileI;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableStrictProfileI;
 import io.github.oliviercailloux.j_voting.profiles.StrictProfileI;
@@ -24,7 +26,7 @@ public class OldFrenchElection implements SocialWelfareFunction {
                     .getLogger(OldFrenchElection.class.getName());
 
     @Override
-    public OldCompletePreferenceImpl getSocietyPreference(ImmutableProfileI profile) {
+    public CompletePreferenceImpl getSocietyPreference(ImmutableProfileI profile) throws Exception {
         LOGGER.debug("getSocietyPreference");
         Preconditions.checkNotNull(profile);
         if (!profile.isStrict()) {

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/SocialWelfareFunction.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/SocialWelfareFunction.java
@@ -1,6 +1,9 @@
 package io.github.oliviercailloux.j_voting.profiles.analysis;
 
 import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableProfileI;
 
 public interface SocialWelfareFunction {
@@ -11,5 +14,5 @@ public interface SocialWelfareFunction {
      * @return a Preference with the society's preference from the profile. This
      *         Preference cannot be empty.
      */
-    public OldCompletePreferenceImpl getSocietyPreference(ImmutableProfileI profile);
+    public CompletePreferenceImpl getSocietyPreference(ImmutableProfileI profile) throws DuplicateValueException, EmptySetException;
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/SocialWelfareFunction.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/analysis/SocialWelfareFunction.java
@@ -14,5 +14,5 @@ public interface SocialWelfareFunction {
      * @return a Preference with the society's preference from the profile. This
      *         Preference cannot be empty.
      */
-    public CompletePreferenceImpl getSocietyPreference(ImmutableProfileI profile) throws DuplicateValueException, EmptySetException;
+    public CompletePreferenceImpl getSocietyPreference(ImmutableProfileI profile) throws Exception;
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/ColumnsDefaultGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/ColumnsDefaultGUI.java
@@ -6,6 +6,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -52,7 +54,7 @@ public class ColumnsDefaultGUI extends ProfileDefaultGUI {
      * @throws IOException
      */
     @Override
-    public void displayProfileWindow(String[] args) throws IOException {
+    public void displayProfileWindow(String[] args) throws IOException, DuplicateValueException, EmptySetException {
         LOGGER.debug("displayProfileWindow");
         Preconditions.checkNotNull(args);
         Preconditions.checkNotNull(args[0]);
@@ -72,7 +74,11 @@ public class ColumnsDefaultGUI extends ProfileDefaultGUI {
 
                 @Override
                 public void widgetSelected(SelectionEvent e) {
-                    save(arg);
+                    try {
+                        save(arg);
+                    } catch (DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException(ex.getMessage());
+                    }
                 }
             });
             saveButton.setVisible(true);
@@ -90,7 +96,7 @@ public class ColumnsDefaultGUI extends ProfileDefaultGUI {
     }
 
     @Override
-    public void tableDisplay() {
+    public void tableDisplay() throws DuplicateValueException, EmptySetException {
         LOGGER.debug("tableDisplay");
         // table layout handling
         mainShell.setLayout(new GridLayout());
@@ -205,7 +211,7 @@ public class ColumnsDefaultGUI extends ProfileDefaultGUI {
      * @param outputFile not <code>null</code>
      */
     @Override
-    public void save(String outputFile) {
+    public void save(String outputFile) throws DuplicateValueException, EmptySetException{
         LOGGER.debug("save :");
         Preconditions.checkNotNull(outputFile);
         File file = new File(outputFile);

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/MainGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/MainGUI.java
@@ -171,9 +171,8 @@ public class MainGUI {
                 } else {
                     try {
                         new SOCColumnsGUI().displayProfileWindow(profileToRead);
-                    } catch (IOException ioe) {
-                        LOGGER.debug("IOException when opening Columns GUI : {}",
-                                        ioe);
+                    } catch (IOException | DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException("Exception when opening Columns GUI : {}" + ex.getMessage());
                     }
                 }
             }
@@ -203,9 +202,8 @@ public class MainGUI {
                     try {
                         new SOCWrappedColumnsGUI()
                                         .displayProfileWindow(profileToRead);
-                    } catch (IOException ioe) {
-                        LOGGER.debug("IOException when opening wrapped GUI : {}",
-                                        ioe);
+                    } catch (IOException | DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException("Exception when opening wrapped GUI : {}" + ex.getMessage());
                     }
                 }
             }
@@ -239,9 +237,8 @@ public class MainGUI {
                 } else {
                     try {
                         new SOIColumnsGUI().displayProfileWindow(profileToRead);
-                    } catch (IOException ioe) {
-                        LOGGER.debug("IOException when opening Columns SOI GUI : {}",
-                                        ioe);
+                    } catch (IOException | DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException("IOException when opening Columns SOI GUI : {}" + ex.getMessage());
                     }
                 }
             }
@@ -271,9 +268,8 @@ public class MainGUI {
                     try {
                         new SOIWrappedColumnsGUI()
                                         .displayProfileWindow(profileToRead);
-                    } catch (IOException ioe) {
-                        LOGGER.debug("IOException when opening Wrapped Columns SOI GUI : {}",
-                                        ioe);
+                    } catch (IOException | DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException("Exception when opening Wrapped Columns SOI GUI : {}" + ex.getMessage());
                     }
                 }
             }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/MainGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/MainGUI.java
@@ -2,6 +2,8 @@ package io.github.oliviercailloux.j_voting.profiles.gui;
 
 import java.io.IOException;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -185,9 +187,8 @@ public class MainGUI {
                 } else {
                     try {
                         new SOCRowsGUI().displayProfileWindow(profileToRead);
-                    } catch (IOException ioe) {
-                        LOGGER.debug("IOException when opening Rows GUI : {}",
-                                        ioe);
+                    } catch (IOException | DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException("Exception when opening Rows SOI GUI : {}" + ex.getMessage());
                     }
                 }
             }
@@ -254,9 +255,8 @@ public class MainGUI {
                 } else {
                     try {
                         new SOIRowsGUI().displayProfileWindow(profileToRead);
-                    } catch (IOException ioe) {
-                        LOGGER.debug("IOException when opening Rows SOI GUI : {}",
-                                        ioe);
+                    } catch (IOException | DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException("Exception when opening Rows SOI GUI : {}" + ex.getMessage());
                     }
                 }
             }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/ProfileDefaultGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/ProfileDefaultGUI.java
@@ -8,6 +8,9 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -30,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.ProfileI;
 import io.github.oliviercailloux.j_voting.profiles.StrictProfile;
@@ -55,7 +57,7 @@ public class ProfileDefaultGUI {
                     SWT.MULTI | SWT.BORDER);
     protected static Table table = tableViewer.getTable();
     protected static Integer voterToModify = null;
-    protected static OldLinearPreferenceImpl newpref;
+    protected static LinearPreferenceImpl newpref;
     protected static ProfileBuilder profileBuilder;
 
     /**
@@ -64,8 +66,10 @@ public class ProfileDefaultGUI {
      * 
      * @param args
      * @throws IOException
+     * @throws EmptySetException  if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      */
-    public void displayProfileWindow(String[] args) throws IOException {
+    public void displayProfileWindow(String[] args) throws IOException, DuplicateValueException, EmptySetException {
         LOGGER.debug("displayProfileWindow");
         Preconditions.checkNotNull(args[0]);
         String arg = args[0];// arg is the file path
@@ -88,7 +92,7 @@ public class ProfileDefaultGUI {
     /**
      * Displays the table containing the profile
      */
-    public void tableDisplay() {
+    public void tableDisplay() throws DuplicateValueException, EmptySetException{
         LOGGER.debug("tableDisplay");
         // table layout handling
         mainShell.setLayout(new GridLayout());
@@ -111,7 +115,7 @@ public class ProfileDefaultGUI {
      * 
      * @param args contains the name of the file with the profile
      */
-    public void displayRadioButtons(String[] args) {
+    public void displayRadioButtons(String[] args) throws DuplicateValueException, EmptySetException {
         LOGGER.debug("displayRadioButtons :");
         columnsButton.setText("Columns");
         rowsButton.setText("Rows");
@@ -132,7 +136,11 @@ public class ProfileDefaultGUI {
                 @Override
                 public void widgetSelected(SelectionEvent e) {
                     emptyTable();
-                    new SOCRowsGUI().tableDisplay();
+                    try {
+                        new SOCRowsGUI().tableDisplay();
+                    } catch (DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException(ex.getMessage());
+                    }
                     table.setRedraw(true);
                 }
             });
@@ -160,7 +168,11 @@ public class ProfileDefaultGUI {
                 @Override
                 public void widgetSelected(SelectionEvent e) {
                     emptyTable();
-                    new SOIRowsGUI().tableDisplay();
+                    try {
+                        new SOIRowsGUI().tableDisplay();
+                    } catch (DuplicateValueException | EmptySetException ex) {
+                       throw new RuntimeException(ex.getMessage());
+                    }
                     table.setRedraw(true);
                 }
             });
@@ -212,8 +224,10 @@ public class ProfileDefaultGUI {
     /**
      * Fills the table of the profile with the alternatives : by default, each
      * column contains the preference of a voter
+     * @throws EmptySetException  if a Set is empty
+      *@throws DuplicateValueException if an Alternative is duplicate
      */
-    public void populateRows() {
+    public void populateRows() throws DuplicateValueException, EmptySetException {
         LOGGER.debug("populateRowsSOI :");
         // ROWS
         StrictProfileI strictProfile = profileBuilder.createStrictProfileI();
@@ -267,10 +281,11 @@ public class ProfileDefaultGUI {
             @Override
             public void handleEvent(Event event) {
                 try {
-                    newpref = new ReadProfile().createStrictPreferenceFrom(
+                    Voter vToManipulatePref = Voter.createVoter(1);
+                    newpref = new ReadProfile().createStrictPreferenceFrom(vToManipulatePref,
                                     textPref.getText());
-                } catch (IllegalArgumentException iae) {
-                    LOGGER.debug("Illegal Argument Exception : {} ", iae);
+                } catch (IllegalArgumentException | DuplicateValueException | EmptySetException ex) {
+                    throw new RuntimeException(ex.getMessage());
                 }
             }
         });

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/ProfileDefaultGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/ProfileDefaultGUI.java
@@ -127,7 +127,11 @@ public class ProfileDefaultGUI {
                 @Override
                 public void widgetSelected(SelectionEvent e) {
                     emptyTable();
-                    new SOCColumnsGUI().tableDisplay();
+                    try {
+                        new SOCColumnsGUI().tableDisplay();
+                    } catch (DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException(ex.getMessage());
+                    }
                     table.setRedraw(true);
                 }
             });
@@ -149,7 +153,11 @@ public class ProfileDefaultGUI {
                 @Override
                 public void widgetSelected(SelectionEvent e) {
                     emptyTable();
-                    new SOCWrappedColumnsGUI().tableDisplay();
+                    try {
+                        new SOCWrappedColumnsGUI().tableDisplay();
+                    } catch (DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException(ex.getMessage());
+                    }
                     table.setRedraw(true);
                 }
             });
@@ -159,7 +167,11 @@ public class ProfileDefaultGUI {
                 @Override
                 public void widgetSelected(SelectionEvent e) {
                     emptyTable();
-                    new SOIColumnsGUI().tableDisplay();
+                    try {
+                        new SOIColumnsGUI().tableDisplay();
+                    } catch (DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException(ex.getMessage());
+                    }
                     table.setRedraw(true);
                 }
             });
@@ -181,7 +193,11 @@ public class ProfileDefaultGUI {
                 @Override
                 public void widgetSelected(SelectionEvent e) {
                     emptyTable();
-                    new SOIWrappedColumnsGUI().tableDisplay();
+                    try {
+                        new SOIWrappedColumnsGUI().tableDisplay();
+                    } catch (DuplicateValueException | EmptySetException ex) {
+                        throw new RuntimeException(ex.getMessage());
+                    }
                     table.setRedraw(true);
                 }
             });
@@ -323,7 +339,7 @@ public class ProfileDefaultGUI {
      * 
      * @param outputFile
      */
-    public void save(String outputFile) {
+    public void save(String outputFile) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("saveButton :");
         Preconditions.checkNotNull(outputFile);
         File file = new File(outputFile);

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCColumnsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCColumnsGUI.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -38,7 +40,7 @@ public class SOCColumnsGUI extends ColumnsDefaultGUI {
     private final Button addAlternativeButton = new Button(mainShell, SWT.PUSH);
 
     @Override
-    public void tableDisplay() {
+    public void tableDisplay() throws DuplicateValueException, EmptySetException{
         LOGGER.debug("tableDisplay");
         // table layout handling
         mainShell.setLayout(new GridLayout());
@@ -81,7 +83,11 @@ public class SOCColumnsGUI extends ColumnsDefaultGUI {
 
             @Override
             public void widgetSelected(SelectionEvent e) {
-                save(MainGUI.fileToRead);
+                try {
+                    save(MainGUI.fileToRead);
+                } catch (DuplicateValueException | EmptySetException ex) {
+                    throw new RuntimeException(ex.getMessage());
+                }
             }
         });
     }
@@ -137,7 +143,7 @@ public class SOCColumnsGUI extends ColumnsDefaultGUI {
     }
 
     @Override
-    public void populateRows() {
+    public void populateRows() throws DuplicateValueException, EmptySetException {
         LOGGER.debug("populateRows :");
         StrictProfile strictProfile = profileBuilder.createStrictProfile();
         // ROWS
@@ -162,7 +168,7 @@ public class SOCColumnsGUI extends ColumnsDefaultGUI {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         SOCColumnsGUI socColumns = new SOCColumnsGUI();
         socColumns.displayProfileWindow(args);
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCRowsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCRowsGUI.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -11,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.StrictProfile;
 
@@ -47,7 +49,7 @@ public class SOCRowsGUI extends ProfileDefaultGUI {
     }
 
     @Override
-    public void populateRows() {
+    public void populateRows() throws DuplicateValueException, EmptySetException {
         LOGGER.debug("populateRows :");
         StrictProfile strictProfile = profileBuilder.createStrictProfile();
         // ROWS
@@ -58,9 +60,8 @@ public class SOCRowsGUI extends ProfileDefaultGUI {
         List<String> line = new ArrayList<>();
         for (Voter v : allVoters) {
             line.add("Voter " + v.getId());
-            OldCompletePreferenceImpl pref = strictProfile.getPreference(v);
-            Iterable<Alternative> allPref = OldCompletePreferenceImpl
-                            .toAlternativeSet(pref.getPreferencesNonStrict());
+            CompletePreferenceImpl pref = strictProfile.getPreference(v);
+            Iterable<Alternative> allPref = pref.getAlternatives();
             for (Alternative a : allPref) {
                 line.add(a.toString());
             }
@@ -74,7 +75,7 @@ public class SOCRowsGUI extends ProfileDefaultGUI {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, DuplicateValueException, EmptySetException {
         SOCRowsGUI socRows = new SOCRowsGUI();
         socRows.displayProfileWindow(args);
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCWrappedColumnsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCWrappedColumnsGUI.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -12,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.StrictProfile;
 
 public class SOCWrappedColumnsGUI extends ColumnsDefaultGUI {
@@ -25,11 +25,11 @@ public class SOCWrappedColumnsGUI extends ColumnsDefaultGUI {
         LOGGER.debug("createColumns :");
         StrictProfile strictProfile = profileBuilder.createStrictProfile();
         // if profile get from file is SOC, create a StrictProfile from it
-        Set<OldCompletePreferenceImpl> uniquePreferences = strictProfile
+        Set<CompletePreferenceImpl> uniquePreferences = strictProfile
                         .getUniquePreferences();
         // COLUMNS
         List<String> titles = new ArrayList<>();
-        for (OldCompletePreferenceImpl p : uniquePreferences) {
+        for (CompletePreferenceImpl p : uniquePreferences) {
             int nbVoters = strictProfile.getNbVoterForPreference(p);
             String voterOrVoters = (nbVoters > 1) ? " voters" : " voter";
             titles.add(nbVoters + voterOrVoters);

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCWrappedColumnsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOCWrappedColumnsGUI.java
@@ -74,7 +74,7 @@ public class SOCWrappedColumnsGUI extends ColumnsDefaultGUI {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         SOCWrappedColumnsGUI socWrapped = new SOCWrappedColumnsGUI();
         socWrapped.displayProfileWindow(args);
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIColumnsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIColumnsGUI.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -38,7 +40,7 @@ public class SOIColumnsGUI extends ColumnsDefaultGUI {
     }
 
     @Override
-    public void populateRows() {
+    public void populateRows() throws EmptySetException, DuplicateValueException {
         LOGGER.debug("populateRows");
         StrictProfileI strictProfile = profileBuilder.createStrictProfileI();
         // ROWS
@@ -53,7 +55,7 @@ public class SOIColumnsGUI extends ColumnsDefaultGUI {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         SOIColumnsGUI soiColumns = new SOIColumnsGUI();
         soiColumns.displayProfileWindow(args);
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIRowsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIRowsGUI.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -11,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.StrictProfileI;
 
@@ -46,7 +48,7 @@ public class SOIRowsGUI extends ProfileDefaultGUI {
     }
 
     @Override
-    public void populateRows() {
+    public void populateRows() throws DuplicateValueException, EmptySetException {
         LOGGER.debug("populateRows :");
         StrictProfileI strictProfile = profileBuilder.createStrictProfileI();
         // ROWS
@@ -57,9 +59,8 @@ public class SOIRowsGUI extends ProfileDefaultGUI {
         List<String> line = new ArrayList<>();
         for (Voter v : allVoters) {
             line.add("Voter " + v.getId());
-            OldCompletePreferenceImpl pref = strictProfile.getPreference(v);
-            Iterable<Alternative> allPref = OldCompletePreferenceImpl
-                            .toAlternativeSet(pref.getPreferencesNonStrict());
+            CompletePreferenceImpl pref = strictProfile.getPreference(v);
+            Iterable<Alternative> allPref = pref.getAlternatives();
             for (Alternative a : allPref) {
                 line.add(a.toString());
             }
@@ -69,7 +70,7 @@ public class SOIRowsGUI extends ProfileDefaultGUI {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, EmptySetException, DuplicateValueException {
         SOIRowsGUI soiRows = new SOIRowsGUI();
         soiRows.displayProfileWindow(args);
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIWrappedColumnsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIWrappedColumnsGUI.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -25,11 +26,11 @@ public class SOIWrappedColumnsGUI extends ColumnsDefaultGUI {
         LOGGER.debug("createColumns :");
         StrictProfileI strictProfile = profileBuilder.createStrictProfileI();
         // if profile get from file is SOC, create a StrictProfile from it
-        Set<OldCompletePreferenceImpl> uniquePreferences = strictProfile
+        Set<CompletePreferenceImpl> uniquePreferences = strictProfile
                         .getUniquePreferences();
         // COLUMNS
         List<String> titles = new ArrayList<>();
-        for (OldCompletePreferenceImpl p : uniquePreferences) {
+        for (CompletePreferenceImpl p : uniquePreferences) {
             int nbVoters = strictProfile.getNbVoterForPreference(p);
             String voterOrVoters = (nbVoters > 1) ? " voters" : " voter";
             titles.add(nbVoters + voterOrVoters);

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIWrappedColumnsGUI.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/gui/SOIWrappedColumnsGUI.java
@@ -65,7 +65,7 @@ public class SOIWrappedColumnsGUI extends ColumnsDefaultGUI {
         }
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         SOIWrappedColumnsGUI soiWrapped = new SOIWrappedColumnsGUI();
         soiWrapped.displayProfileWindow(args);
     }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ProfileBuilder.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ProfileBuilder.java
@@ -4,12 +4,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableProfile;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableProfileI;
@@ -29,7 +30,7 @@ public class ProfileBuilder {
 
     private static final Logger LOGGER = LoggerFactory
                     .getLogger(ProfileBuilder.class.getName());
-    protected Map<Voter, OldCompletePreferenceImpl> votes;
+    protected Map<Voter, CompletePreferenceImpl> votes;
     protected int nextVoterId = 1;
 
     protected ProfileBuilder() {
@@ -49,7 +50,7 @@ public class ProfileBuilder {
      * 
      *             adds the preference pref for the voter v in the map.
      */
-    public void addVote(Voter v, OldCompletePreferenceImpl pref) {
+    public void addVote(Voter v, CompletePreferenceImpl pref) {
         LOGGER.debug("addProfile:");
         Preconditions.checkNotNull(v);
         Preconditions.checkNotNull(pref);
@@ -65,7 +66,7 @@ public class ProfileBuilder {
      * @param nbVoters <code>not null</code> the number of voters that voted for
      *                 the preference as parameter
      */
-    public void addVotes(OldCompletePreferenceImpl pref, int nbVoters) {
+    public void addVotes(CompletePreferenceImpl pref, int nbVoters) {
         LOGGER.debug("AddVotes");
         Preconditions.checkNotNull(pref);
         Preconditions.checkNotNull(nbVoters);
@@ -142,11 +143,11 @@ public class ProfileBuilder {
      * @return a map of voters and preferences (cast to the most general class :
      *         Preference)
      */
-    public static Map<Voter, OldCompletePreferenceImpl> castMapExtendsToRegularVoterPref(
-                    Map<Voter, ? extends OldCompletePreferenceImpl> map) {
+    public static Map<Voter, CompletePreferenceImpl> castMapExtendsToRegularVoterPref(
+                    Map<Voter, ? extends CompletePreferenceImpl> map) {
         LOGGER.debug("castMapToRegularVoterPref");
         Preconditions.checkNotNull(map);
-        Map<Voter, OldCompletePreferenceImpl> result = new HashMap<>();
+        Map<Voter, CompletePreferenceImpl> result = new HashMap<>();
         for (Voter v : map.keySet()) {
             LOGGER.debug("adds the voter {} and his preference {}", v,
                             map.get(v));

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
@@ -164,8 +164,8 @@ public class ReadProfile {
      * @return a StrictProfile
      * @throws IOException
      * @throws URISyntaxException
-     * @throws DuplicateValueException
-     * @throws EmptySetException
+     * @throws EmptySetException if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      */
     public ProfileI createProfileFromURL(URL url) throws IOException, DuplicateValueException, EmptySetException {
         LOGGER.debug("CreateProfileFromURL : ");
@@ -206,6 +206,8 @@ public class ReadProfile {
      *                      containing an alternative
      * @return the Alternatives, in the list of strings, given as a
      *         StrictPreference.
+     * @throws EmptySetException if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      */
     private LinearPreferenceImpl getAlternatives(List<String> listOfStrings) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("GetAlternatives :");
@@ -247,10 +249,12 @@ public class ReadProfile {
      *                          containing the number of voters for a preference
      *                          followed by the preference (list of
      *                          alternatives)
+     * @throws EmptySetException if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      * @return the StrictPreference given in the line s1
      */
     public LinearPreferenceImpl getPreferences(LinearPreferenceImpl listeAlternatives,
-                    String s1) {
+                    String s1) throws DuplicateValueException, EmptySetException{
         LOGGER.debug("GetPreferences");
         Preconditions.checkNotNull(listeAlternatives);
         Preconditions.checkNotNull(s1);
@@ -271,7 +275,8 @@ public class ReadProfile {
                                 "The line s1 contains an alternative that is not in the profile's alternatives");
             }
         }
-        return LinearPreferenceImpl.asLinearPreference(pref);
+        Voter voterToManipulatePref = Voter.createVoter(1);
+        return (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(voterToManipulatePref, pref);
     }
 
     /**
@@ -279,6 +284,8 @@ public class ReadProfile {
      * @param stringPreference not <code>null</null>
      * @return the strictPreference in the string. The string only contains the
      *         alternatives.
+     * @throws EmptySetException if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      */
     public LinearPreferenceImpl createStrictPreferenceFrom(Voter v,
                     String stringPreference) throws EmptySetException, DuplicateValueException{
@@ -303,10 +310,12 @@ public class ReadProfile {
      * @param listAlternatives <code>not null</code> the alternatives of the
      *                         profile
      * @param nbVoters         <code>not null</code> the number of voters
+     * @throws DuplicateValueException
+     * @throws EmptySetException
      * @return the created StrictProfile
      */
     public ProfileI buildProfile(List<String> file,
-                    LinearPreferenceImpl listAlternatives, int nbVoters) {
+                    LinearPreferenceImpl listAlternatives, int nbVoters) throws DuplicateValueException, EmptySetException {
         LOGGER.debug("BuildProfiles :");
         Preconditions.checkNotNull(file);
         Preconditions.checkNotNull(listAlternatives);

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
@@ -51,8 +51,8 @@ public class ReadProfile {
      *           to be extracted. InputStream is closed in this method.
      * @return sProfile a StrictProfile
      * @throws IOException
-     * @throws DuplicateValueException
-     * @throws EmptySetException
+     * @throws EmptySetException  if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      */
     public ProfileI createProfileFromStream(InputStream is) throws IOException, DuplicateValueException, EmptySetException {
         LOGGER.debug("CreateProfileFromReadFile : ");
@@ -97,7 +97,8 @@ public class ReadProfile {
     }
 
     /**
-     * 
+     * @throws EmptySetException  if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      * @param table not <code>null</code> a Table displayed as Voters in columns
      * @return a restricted ProfileI
      */
@@ -127,7 +128,8 @@ public class ReadProfile {
     }
 
     /**
-     * 
+     * @throws EmptySetException  if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      * @param table <code>null</code> a Table displayed as Voters in rows
      * @return a restricted ProfileI
      */

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
@@ -101,7 +101,7 @@ public class ReadProfile {
      * @param table not <code>null</code> a Table displayed as Voters in columns
      * @return a restricted ProfileI
      */
-    public ProfileI createProfileFromColumnsTable(Table table) {
+    public ProfileI createProfileFromColumnsTable(Table table) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("createProfileFromColumnsTable : ");
         Preconditions.checkNotNull(table);
         ProfileBuilder profileBuilder = ProfileBuilder.createProfileBuilder();
@@ -119,7 +119,7 @@ public class ReadProfile {
             }
             Voter voter = Voter.createVoter(column + 1);
             LinearPreferenceImpl newPref = new ReadProfile()
-                            .createStrictPreferenceFrom(
+                            .createStrictPreferenceFrom(voter,
                                             newPrefString.toString());
             profileBuilder.addVote(voter, newPref);
         }

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfile.java
@@ -15,6 +15,8 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.slf4j.Logger;
@@ -26,7 +28,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.io.CharStreams;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.ProfileI;
 
@@ -49,8 +51,10 @@ public class ReadProfile {
      *           to be extracted. InputStream is closed in this method.
      * @return sProfile a StrictProfile
      * @throws IOException
+     * @throws DuplicateValueException
+     * @throws EmptySetException
      */
-    public ProfileI createProfileFromStream(InputStream is) throws IOException {
+    public ProfileI createProfileFromStream(InputStream is) throws IOException, DuplicateValueException, EmptySetException {
         LOGGER.debug("CreateProfileFromReadFile : ");
         Preconditions.checkNotNull(is);
         try (InputStreamReader isr = new InputStreamReader(is,
@@ -86,7 +90,7 @@ public class ReadProfile {
             }
             LOGGER.debug("lines with the number of votes for each StrictPreference : {}",
                             profiles);
-            OldLinearPreferenceImpl listeAlternatives = getAlternatives(alternatives);
+            LinearPreferenceImpl listeAlternatives = getAlternatives(alternatives);
             List<Integer> listInt = getStatsVoters(lineNbVoters);
             return buildProfile(profiles, listeAlternatives, listInt.get(0));
         }
@@ -114,7 +118,7 @@ public class ReadProfile {
                 }
             }
             Voter voter = Voter.createVoter(column + 1);
-            OldLinearPreferenceImpl newPref = new ReadProfile()
+            LinearPreferenceImpl newPref = new ReadProfile()
                             .createStrictPreferenceFrom(
                                             newPrefString.toString());
             profileBuilder.addVote(voter, newPref);
@@ -127,7 +131,7 @@ public class ReadProfile {
      * @param table <code>null</code> a Table displayed as Voters in rows
      * @return a restricted ProfileI
      */
-    public ProfileI createProfileFromRowsTable(Table table) {
+    public ProfileI createProfileFromRowsTable(Table table) throws EmptySetException, DuplicateValueException{
         LOGGER.debug("createProfileFromRowsTable : ");
         Preconditions.checkNotNull(table);
         ProfileBuilder profileBuilder = ProfileBuilder.createProfileBuilder();
@@ -143,8 +147,8 @@ public class ReadProfile {
                 }
             }
             Voter voter = Voter.createVoter(item + 1);
-            OldLinearPreferenceImpl newPref = new ReadProfile()
-                            .createStrictPreferenceFrom(
+            LinearPreferenceImpl newPref = new ReadProfile()
+                            .createStrictPreferenceFrom(voter,
                                             newPrefString.toString());
             profileBuilder.addVote(voter, newPref);
         }
@@ -160,8 +164,10 @@ public class ReadProfile {
      * @return a StrictProfile
      * @throws IOException
      * @throws URISyntaxException
+     * @throws DuplicateValueException
+     * @throws EmptySetException
      */
-    public ProfileI createProfileFromURL(URL url) throws IOException {
+    public ProfileI createProfileFromURL(URL url) throws IOException, DuplicateValueException, EmptySetException {
         LOGGER.debug("CreateProfileFromURL : ");
         Preconditions.checkNotNull(url);
         LOGGER.debug("parameter : URL = {}", url);
@@ -201,7 +207,7 @@ public class ReadProfile {
      * @return the Alternatives, in the list of strings, given as a
      *         StrictPreference.
      */
-    private OldLinearPreferenceImpl getAlternatives(List<String> listOfStrings) {
+    private LinearPreferenceImpl getAlternatives(List<String> listOfStrings) throws EmptySetException, DuplicateValueException {
         LOGGER.debug("GetAlternatives :");
         Preconditions.checkNotNull(listOfStrings);
         LOGGER.debug("parameter : file = {}", listOfStrings);
@@ -210,7 +216,8 @@ public class ReadProfile {
             LOGGER.debug("next Alternative : {}", alternative);
             alternatives.add(Alternative.withId(Integer.parseInt(alternative)));
         }
-        OldLinearPreferenceImpl listAlternatives = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives);
+        Voter voterToManipulatePref = Voter.createVoter(1);
+        LinearPreferenceImpl listAlternatives = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(voterToManipulatePref, alternatives);
         LOGGER.debug("returns listAlternatives : {}", listAlternatives);
         return listAlternatives;
     }
@@ -242,7 +249,7 @@ public class ReadProfile {
      *                          alternatives)
      * @return the StrictPreference given in the line s1
      */
-    public OldLinearPreferenceImpl getPreferences(OldLinearPreferenceImpl listeAlternatives,
+    public LinearPreferenceImpl getPreferences(LinearPreferenceImpl listeAlternatives,
                     String s1) {
         LOGGER.debug("GetPreferences");
         Preconditions.checkNotNull(listeAlternatives);
@@ -255,7 +262,7 @@ public class ReadProfile {
                         1)) {
             Alternative alter = Alternative.withId(Integer.parseInt(alternative.trim()));
             LOGGER.debug("next alternative {}", alter.getId());
-            if (listeAlternatives.contains(alter)) {
+            if (listeAlternatives.getAlternatives().contains(alter)) {
                 LOGGER.debug("correct alternative");
                 pref.add(alter);
             } else {
@@ -264,7 +271,7 @@ public class ReadProfile {
                                 "The line s1 contains an alternative that is not in the profile's alternatives");
             }
         }
-        return OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(pref);
+        return LinearPreferenceImpl.asLinearPreference(pref);
     }
 
     /**
@@ -273,8 +280,8 @@ public class ReadProfile {
      * @return the strictPreference in the string. The string only contains the
      *         alternatives.
      */
-    public OldLinearPreferenceImpl createStrictPreferenceFrom(
-                    String stringPreference) {
+    public LinearPreferenceImpl createStrictPreferenceFrom(Voter v,
+                    String stringPreference) throws EmptySetException, DuplicateValueException{
         LOGGER.debug("GetPreferences");
         Preconditions.checkNotNull(stringPreference);
         LOGGER.debug("parameters : s1 {}", stringPreference);
@@ -287,7 +294,7 @@ public class ReadProfile {
         }
         if (pref.isEmpty())
             throw new IllegalArgumentException("The preference is empty.");
-        return OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(pref);
+        return (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v, pref);
     }
 
     /**
@@ -299,7 +306,7 @@ public class ReadProfile {
      * @return the created StrictProfile
      */
     public ProfileI buildProfile(List<String> file,
-                    OldLinearPreferenceImpl listAlternatives, int nbVoters) {
+                    LinearPreferenceImpl listAlternatives, int nbVoters) {
         LOGGER.debug("BuildProfiles :");
         Preconditions.checkNotNull(file);
         Preconditions.checkNotNull(listAlternatives);
@@ -313,7 +320,7 @@ public class ReadProfile {
                                 "the first string of file is an alternative line.");
             }
             String[] lineAsArray = line.split(",");
-            OldLinearPreferenceImpl pref = getPreferences(listAlternatives, line);
+            LinearPreferenceImpl pref = getPreferences(listAlternatives, line);
             LOGGER.debug("to add : {} votes for the StrictPreference {}",
                             lineAsArray[0].trim(), pref);
             profile.addVotes(pref, Integer.parseInt(lineAsArray[0].trim()));

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/SWFCommander.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/SWFCommander.java
@@ -3,6 +3,9 @@ package io.github.oliviercailloux.j_voting.profiles.management;
 import java.io.IOException;
 import java.util.Scanner;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +40,8 @@ public class SWFCommander {
      * @return the entered StrictPreference
      * @throws IOException when the entered preference is empty.
      */
-    public static OldLinearPreferenceImpl askPreference()
-                    throws IOException {
+    public static LinearPreferenceImpl askPreference()
+                    throws IOException, DuplicateValueException, EmptySetException {
         LOGGER.debug("askPreference");
         System.out.println("Enter a StrictPreference complete");
         try (Scanner scan = new Scanner(System.in)) {
@@ -47,7 +50,8 @@ public class SWFCommander {
             if (vote.isEmpty()) {
                 throw new IOException("empty Preference entered !");
             }
-            return new ReadProfile().createStrictPreferenceFrom(vote);
+            Voter interrogedVoter = Voter.createVoter(1);
+            return new ReadProfile().createStrictPreferenceFrom(interrogedVoter, vote);
         }
     }
 
@@ -59,7 +63,7 @@ public class SWFCommander {
      * 
      * @throws IOException when the entered preference is empty.
      */
-    public void createProfileIncrementally() throws IOException {
+    public void createProfileIncrementally() throws Exception {
         LOGGER.debug("createProfileIncrementally:");
         StrictProfileBuilder prof = StrictProfileBuilder
                         .createStrictProfileBuilder();
@@ -68,9 +72,9 @@ public class SWFCommander {
         while (keepGoing) {
             LOGGER.debug("new voter id  : {}", voterId);
             Voter v = Voter.createVoter(voterId);
-            OldLinearPreferenceImpl oldLinearPreferenceImpl = askPreference();
-            LOGGER.debug("strictPreference :{}", oldLinearPreferenceImpl);
-            prof.addVote(v, oldLinearPreferenceImpl);
+            LinearPreferenceImpl linearPreferenceImpl = askPreference();
+            LOGGER.debug("strictPreference :{}", linearPreferenceImpl);
+            prof.addVote(v, linearPreferenceImpl);
             LOGGER.info("Continue ? (yes/no)");
             try (Scanner scn = new Scanner(System.in)) {
                 String answer = scn.nextLine();

--- a/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/StrictProfileBuilder.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/profiles/management/StrictProfileBuilder.java
@@ -5,13 +5,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.LinearPreference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.CompletePreference;
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableStrictProfileI;
@@ -71,7 +76,7 @@ public class StrictProfileBuilder extends ProfileBuilder {
      *             IllegalArgumentException.
      */
     @Override
-    public void addVote(Voter v, OldCompletePreferenceImpl pref) {
+    public void addVote(Voter v, CompletePreferenceImpl pref) {
         LOGGER.debug("addProfile:");
         Preconditions.checkNotNull(v);
         Preconditions.checkNotNull(pref);
@@ -86,16 +91,17 @@ public class StrictProfileBuilder extends ProfileBuilder {
     /**
      * From a StrictProfileI, creates an ImmutableStrictProfileI where only the
      * first alternative of each preference is taken into account.
-     * 
+     * @throws EmptySetException  if a Set is empty
+     * @throws DuplicateValueException if an Alternative is duplicate
      * @return
      */
-    public ImmutableStrictProfileI createOneAlternativeProfile() {
+    public ImmutableStrictProfileI createOneAlternativeProfile() throws DuplicateValueException, EmptySetException {
         LOGGER.debug("createOneAlternativeProfile");
         for (Voter v : votes.keySet()) {
             List<Alternative> alters = new ArrayList<>();
-            alters.add(votes.get(v).getAlternative(0));
-            OldLinearPreferenceImpl prefOneAlter = OldLinearPreferenceImpl
-                            .createStrictCompletePreferenceImpl(alters);
+            alters.add(votes.get(v).getAlternatives().asList().get(0));
+            LinearPreferenceImpl prefOneAlter = (LinearPreferenceImpl) LinearPreferenceImpl
+                            .asLinearPreference(v, alters);
             addVote(v, prefOneAlter);
         }
         return ImmutableStrictProfileI.createImmutableStrictProfileI(votes);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileITest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileITest.java
@@ -175,10 +175,10 @@ public class ImmutableProfileITest {
         for (CompletePreferenceImpl p : createIPIToTest().getUniquePreferences()) {
             preferencelist.add(p);
         }
-        boolean case1 = preferencelist.get(0).equals(pref1V1)
-                        && preferencelist.get(1).equals(pref2V1);
-        boolean case2 = preferencelist.get(0).equals(pref2V1)
-                        && preferencelist.get(1).equals(pref1V1);
+        boolean case1 = preferencelist.get(0).asEquivalenceClasses().equals(pref1V1.asEquivalenceClasses())
+                        && preferencelist.get(1).asEquivalenceClasses().equals(pref2V1.asEquivalenceClasses());
+        boolean case2 = preferencelist.get(0).asEquivalenceClasses().equals(pref2V1.asEquivalenceClasses())
+                        && preferencelist.get(1).asEquivalenceClasses().equals(pref1V1.asEquivalenceClasses());
         assertTrue(case1 || case2);
     }
 

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileITest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileITest.java
@@ -12,8 +12,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
 
-import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
-import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+
 import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.preferences.interfaces.CompletePreference;
 import io.github.oliviercailloux.j_voting.preferences.interfaces.ImmutablePreference;
@@ -29,7 +28,7 @@ import io.github.oliviercailloux.j_voting.profiles.management.ProfileBuilder;
 
 public class ImmutableProfileITest {
 
-    public static ImmutableProfileI createIPIToTest() throws EmptySetException, DuplicateValueException {
+    public static ImmutableProfileI createIPIToTest() throws Exception {
         Map<Voter, CompletePreferenceImpl> profile = new HashMap<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileITest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileITest.java
@@ -260,7 +260,7 @@ public class ImmutableProfileITest {
     }
 
     @Test
-    public void testRestrictProfile() {
+    public void testRestrictProfile() throws Exception {
         ProfileI prof = ImmutableStrictProfileTest.createISPToTest()
                         .restrictProfile();
         assertTrue(prof instanceof ImmutableStrictProfile);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableProfileTest.java
@@ -9,6 +9,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.junit.jupiter.api.Test;
 
 import io.github.oliviercailloux.j_voting.Alternative;
@@ -18,8 +21,8 @@ import io.github.oliviercailloux.j_voting.profiles.ImmutableProfile;
 
 public class ImmutableProfileTest {
 
-    public static ImmutableProfile createIPToTest() {
-        Map<Voter, OldCompletePreferenceImpl> profile = new HashMap<>();
+    public static ImmutableProfile createIPToTest() throws EmptySetException, DuplicateValueException {
+        Map<Voter, CompletePreferenceImpl> profile = new HashMap<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -45,24 +48,28 @@ public class ImmutableProfileTest {
         list1.add(s2);
         list2.add(s3);
         list2.add(s4);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
-        OldCompletePreferenceImpl pref2 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list2);
-        profile.put(v1, pref1);
-        profile.put(v2, pref1);
-        profile.put(v3, pref1);
-        profile.put(v4, pref1);
-        profile.put(v5, pref2);
-        profile.put(v6, pref2);
+        CompletePreferenceImpl pref1V1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v1, list1);
+        CompletePreferenceImpl pref1V2 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v2, list1);
+        CompletePreferenceImpl pref1V3 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v3, list1);
+        CompletePreferenceImpl pref1V4 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v4, list1);
+        CompletePreferenceImpl pref2V5 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v5, list2);
+        CompletePreferenceImpl pref2V6 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v6, list2);
+        profile.put(v1, pref1V1);
+        profile.put(v2, pref1V2);
+        profile.put(v3, pref1V3);
+        profile.put(v4, pref1V4);
+        profile.put(v5, pref2V5);
+        profile.put(v6, pref2V6);
         return ImmutableProfile.createImmutableProfile(profile);
     }
 
     @Test
-    public void testGetNbAlternatives() {
+    public void testGetNbAlternatives() throws Exception {
         assertEquals(createIPToTest().getNbAlternatives(), 3);
     }
 
     @Test
-    public void testGetAlternatives() {
+    public void testGetAlternatives() throws Exception {
         Set<Alternative> alters = new HashSet<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileITest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileITest.java
@@ -12,9 +12,11 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
-import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableStrictProfileI;
 
 public class ImmutableStrictProfileITest {
@@ -22,9 +24,11 @@ public class ImmutableStrictProfileITest {
     /**
      * 
      * @return an ImmutableStrictProfileI to test
+     * @throws DuplicateValueException 
+     * @throws EmptySetException 
      */
-    public static ImmutableStrictProfileI createISPIToTest() {
-        Map<Voter, OldLinearPreferenceImpl> profile = new HashMap<>();
+    public static ImmutableStrictProfileI createISPIToTest() throws Exception {
+        Map<Voter, LinearPreferenceImpl> profile = new HashMap<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -41,23 +45,29 @@ public class ImmutableStrictProfileITest {
         list1.add(a3);
         list2.add(a3);
         list2.add(a2);
-        OldLinearPreferenceImpl pref1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list2);
-        profile.put(v1, pref1);
-        profile.put(v2, pref1);
-        profile.put(v3, pref1);
-        profile.put(v4, pref1);
-        profile.put(v5, pref2);
-        profile.put(v6, pref2);
+        LinearPreferenceImpl pref1V1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl pref1V2 = LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl pref1V3 = LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl pref1V4 = LinearPreferenceImpl.asLinearPreference(v4, list1);
+        LinearPreferenceImpl pref2V5 = LinearPreferenceImpl.asLinearPreference(v6, list2);
+        LinearPreferenceImpl pref2V6 = LinearPreferenceImpl.asLinearPreference(v6, list2);
+        profile.put(v1, pref1V1);
+        profile.put(v2, pref1V2);
+        profile.put(v3, pref1V3);
+        profile.put(v4, pref1V4);
+        profile.put(v5, pref2V5);
+        profile.put(v6, pref2V6);
         return ImmutableStrictProfileI.createImmutableStrictProfileI(profile);
     }
 
     /**
      * 
      * @return a map of Voter and Preference to test
+     * @throws EmptySetException 
+     * @throws DuplicateValueException 
      */
-    public static Map<Voter, OldCompletePreferenceImpl> createNonStrictMap() {
-        Map<Voter, OldCompletePreferenceImpl> map = new HashMap<>();
+    public static Map<Voter, CompletePreferenceImpl> createNonStrictMap() throws Exception {
+        Map<Voter, CompletePreferenceImpl> map = new HashMap<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -78,20 +88,23 @@ public class ImmutableStrictProfileITest {
         list2.add(s3);
         list2.add(s2);
         list2.add(s1);
-        OldCompletePreferenceImpl p1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
-        OldCompletePreferenceImpl p2 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list2);
-        map.put(v1, p1);
-        map.put(v2, p1);
-        map.put(v3, p2);
+        CompletePreferenceImpl p1V1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v1, list1);
+        CompletePreferenceImpl p1V2 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v2, list1);
+        CompletePreferenceImpl p2V3 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v3, list1);
+        map.put(v1, p1V1);
+        map.put(v2, p1V2);
+        map.put(v3, p2V3);
         return map;
     }
 
     /**
      * 
      * @return a map of Voter and StrictPreference to test
+     * @throws DuplicateValueException 
+     * @throws EmptySetException 
      */
-    public static Map<Voter, OldLinearPreferenceImpl> createStrictMap() {
-        Map<Voter, OldLinearPreferenceImpl> map = new HashMap<>();
+    public static Map<Voter, LinearPreferenceImpl> createStrictMap() throws Exception {
+        Map<Voter, LinearPreferenceImpl> map = new HashMap<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -106,16 +119,17 @@ public class ImmutableStrictProfileITest {
         list2.add(a3);
         list2.add(a2);
         list2.add(a1);
-        OldLinearPreferenceImpl p1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
-        OldLinearPreferenceImpl p2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list2);
-        map.put(v1, p1);
-        map.put(v2, p1);
-        map.put(v3, p2);
+        LinearPreferenceImpl p1V1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl p1V2 = LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl p2V3 = LinearPreferenceImpl.asLinearPreference(v3, list1);
+        map.put(v1, p1V1);
+        map.put(v2, p1V2);
+        map.put(v3, p2V3);
         return map;
     }
 
     @Test
-    public void testGetPreferenceVoter() {
+    public void testGetPreferenceVoter() throws Exception {
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -124,7 +138,7 @@ public class ImmutableStrictProfileITest {
         list1.add(a1);
         list1.add(a2);
         list1.add(a3);
-        OldLinearPreferenceImpl pref1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
+        LinearPreferenceImpl pref1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
         assertEquals(pref1, createISPIToTest().getPreference(v1));
     }
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileITest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileITest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.Voter;
-import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
-import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableStrictProfileI;

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileITest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileITest.java
@@ -45,12 +45,12 @@ public class ImmutableStrictProfileITest {
         list1.add(a3);
         list2.add(a3);
         list2.add(a2);
-        LinearPreferenceImpl pref1V1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
-        LinearPreferenceImpl pref1V2 = LinearPreferenceImpl.asLinearPreference(v2, list1);
-        LinearPreferenceImpl pref1V3 = LinearPreferenceImpl.asLinearPreference(v3, list1);
-        LinearPreferenceImpl pref1V4 = LinearPreferenceImpl.asLinearPreference(v4, list1);
-        LinearPreferenceImpl pref2V5 = LinearPreferenceImpl.asLinearPreference(v6, list2);
-        LinearPreferenceImpl pref2V6 = LinearPreferenceImpl.asLinearPreference(v6, list2);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl pref1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl pref1V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl pref1V4 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v4, list1);
+        LinearPreferenceImpl pref2V5 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list2);
+        LinearPreferenceImpl pref2V6 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list2);
         profile.put(v1, pref1V1);
         profile.put(v2, pref1V2);
         profile.put(v3, pref1V3);
@@ -119,9 +119,9 @@ public class ImmutableStrictProfileITest {
         list2.add(a3);
         list2.add(a2);
         list2.add(a1);
-        LinearPreferenceImpl p1V1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
-        LinearPreferenceImpl p1V2 = LinearPreferenceImpl.asLinearPreference(v2, list1);
-        LinearPreferenceImpl p2V3 = LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl p1V1 = (LinearPreferenceImpl)LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl p1V2 = (LinearPreferenceImpl)LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl p2V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, list1);
         map.put(v1, p1V1);
         map.put(v2, p1V2);
         map.put(v3, p2V3);
@@ -138,7 +138,7 @@ public class ImmutableStrictProfileITest {
         list1.add(a1);
         list1.add(a2);
         list1.add(a3);
-        LinearPreferenceImpl pref1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl pref1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, list1);
         assertEquals(pref1, createISPIToTest().getPreference(v1));
     }
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileTest.java
@@ -43,12 +43,12 @@ public class ImmutableStrictProfileTest {
         list2.add(a3);
         list2.add(a2);
         list2.add(a1);
-        LinearPreferenceImpl p1V1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
-        LinearPreferenceImpl p1V2 = LinearPreferenceImpl.asLinearPreference(v2, list1);
-        LinearPreferenceImpl p1V3 = LinearPreferenceImpl.asLinearPreference(v3, list1);
-        LinearPreferenceImpl p1V4 = LinearPreferenceImpl.asLinearPreference(v4, list1);
-        LinearPreferenceImpl p2V5 = LinearPreferenceImpl.asLinearPreference(v6, list2);
-        LinearPreferenceImpl p2V6 = LinearPreferenceImpl.asLinearPreference(v6, list2);
+        LinearPreferenceImpl p1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl p1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl p1V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl p1V4 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v4, list1);
+        LinearPreferenceImpl p2V5 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list2);
+        LinearPreferenceImpl p2V6 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list2);
 
         profile.put(v1, p1V1);
         profile.put(v2, p1V2);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/ImmutableStrictProfileTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableStrictProfile;
 
 public class ImmutableStrictProfileTest {
@@ -20,9 +21,11 @@ public class ImmutableStrictProfileTest {
     /**
      * 
      * @return an ImmutableStrictProfileI to test
+     * @throws DuplicateValueException 
+     * @throws EmptySetException 
      */
-    public static ImmutableStrictProfile createISPToTest() {
-        Map<Voter, OldLinearPreferenceImpl> profile = new HashMap<>();
+    public static ImmutableStrictProfile createISPToTest() throws Exception {
+        Map<Voter, LinearPreferenceImpl> profile = new HashMap<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -40,24 +43,29 @@ public class ImmutableStrictProfileTest {
         list2.add(a3);
         list2.add(a2);
         list2.add(a1);
-        OldLinearPreferenceImpl pref1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list2);
-        profile.put(v1, pref1);
-        profile.put(v2, pref1);
-        profile.put(v3, pref1);
-        profile.put(v4, pref1);
-        profile.put(v5, pref2);
-        profile.put(v6, pref2);
+        LinearPreferenceImpl p1V1 = LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl p1V2 = LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl p1V3 = LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl p1V4 = LinearPreferenceImpl.asLinearPreference(v4, list1);
+        LinearPreferenceImpl p2V5 = LinearPreferenceImpl.asLinearPreference(v6, list2);
+        LinearPreferenceImpl p2V6 = LinearPreferenceImpl.asLinearPreference(v6, list2);
+
+        profile.put(v1, p1V1);
+        profile.put(v2, p1V2);
+        profile.put(v3, p1V3);
+        profile.put(v4, p1V4);
+        profile.put(v5, p2V5);
+        profile.put(v6, p2V6);
         return ImmutableStrictProfile.createImmutableStrictProfile(profile);
     }
 
     @Test
-    public void testGetNbAlternatives() {
+    public void testGetNbAlternatives() throws Exception {
         assertEquals(createISPToTest().getNbAlternatives(), 3);
     }
 
     @Test
-    public void testGetAlternatives() {
+    public void testGetAlternatives() throws Exception {
         Set<Alternative> alters = new HashSet<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/BordaTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/BordaTest.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.HashMultiset;
@@ -24,8 +27,8 @@ import io.github.oliviercailloux.j_voting.profiles.analysis.Borda;
 
 public class BordaTest {
 
-    public static ImmutableProfileI createIPIToTest() {
-        Map<Voter, OldCompletePreferenceImpl> profile = new HashMap<>();
+    public static ImmutableProfileI createIPIToTest() throws DuplicateValueException, EmptySetException {
+        Map<Voter, CompletePreferenceImpl> profile = new HashMap<>();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -51,19 +54,23 @@ public class BordaTest {
         list1.add(s2);
         list2.add(s3);
         list2.add(s4);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
-        OldCompletePreferenceImpl pref2 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list2);
-        profile.put(v1, pref1);
-        profile.put(v2, pref1);
-        profile.put(v3, pref1);
-        profile.put(v4, pref1);
-        profile.put(v5, pref2);
-        profile.put(v6, pref2);
+        CompletePreferenceImpl pref1V1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v1, list1);
+        CompletePreferenceImpl pref1V2 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v2, list1);
+        CompletePreferenceImpl pref1V3 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v3, list1);
+        CompletePreferenceImpl pref1V4 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v4, list1);
+        CompletePreferenceImpl pref2V5 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v5, list2);
+        CompletePreferenceImpl pref2V6 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v6, list2);
+        profile.put(v1, pref1V1);
+        profile.put(v2, pref1V2);
+        profile.put(v3, pref1V3);
+        profile.put(v4, pref1V4);
+        profile.put(v5, pref2V5);
+        profile.put(v6, pref2V6);
         return ImmutableProfileI.createImmutableProfileI(profile);
     }
 
     @Test
-    public void testgetSocietyPreference() {
+    public void testgetSocietyPreference() throws Exception {
         ImmutableProfileI prof = createIPIToTest();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
@@ -78,12 +85,13 @@ public class BordaTest {
         list1.add(s2);
         list1.add(s1);
         list1.add(s3);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
+        Voter society = Voter.createVoter(1);
+        CompletePreferenceImpl pref1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(society, list1);
         assertEquals(Borda.withScores().getSocietyPreference(prof), pref1);
     }
 
     @Test
-    public void testSetScoresPref() {
+    public void testSetScoresPref() throws Exception {
         Borda b = Borda.withScores();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
@@ -96,7 +104,8 @@ public class BordaTest {
         s2.add(a3);
         list1.add(s1);
         list1.add(s2);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
+        Voter voterTest = Voter.createVoter(2);
+        CompletePreferenceImpl pref1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(voterTest, list1);
         b.setScores(pref1);
         Multiset<Alternative> m = b.getMultiSet();
         assertEquals(m.count(a1), 2);
@@ -105,7 +114,7 @@ public class BordaTest {
     }
 
     @Test
-    public void testSetScoresProfile() {
+    public void testSetScoresProfile() throws Exception {
         Borda b = Borda.withScores();
         ProfileI p = createIPIToTest();
         Alternative a1 = Alternative.withId(1);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/DictatorTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/DictatorTest.java
@@ -11,8 +11,10 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import io.github.oliviercailloux.j_voting.Alternative;
-import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableProfileI;
 import io.github.oliviercailloux.j_voting.profiles.ProfileI;
 import io.github.oliviercailloux.j_voting.profiles.analysis.Dictator;
@@ -21,7 +23,7 @@ import io.github.oliviercailloux.j_voting.profiles.management.ProfileBuilder;
 public class DictatorTest {
 
     @Test
-    public void getSocietyPreferenceTest() {
+    public void getSocietyPreferenceTest() throws Exception {
         Voter v1 = Voter.createVoter(1);
         Voter v2 = Voter.createVoter(2);
         Voter v3 = Voter.createVoter(3);
@@ -44,9 +46,9 @@ public class DictatorTest {
         list1.add(s2);
         list2.add(s2);
         list3.add(s3);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
-        OldCompletePreferenceImpl pref2 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list2);
-        OldCompletePreferenceImpl pref3 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list3);
+        CompletePreferenceImpl pref1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v1, list1);
+        CompletePreferenceImpl pref2 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v2, list2);
+        CompletePreferenceImpl pref3 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v3, list3);
         ProfileBuilder prof = ProfileBuilder.createProfileBuilder();
         prof.addVote(v1, pref1);
         prof.addVote(v2, pref2);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/FrenchElectionTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/FrenchElectionTest.java
@@ -13,6 +13,10 @@ import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableStrictProfileI;
 import io.github.oliviercailloux.j_voting.profiles.analysis.OldFrenchElection;
 import io.github.oliviercailloux.j_voting.profiles.management.StrictProfileBuilder;
@@ -20,7 +24,7 @@ import io.github.oliviercailloux.j_voting.profiles.management.StrictProfileBuild
 public class FrenchElectionTest {
 
     @Test
-    public void testGetSocietyPreference() {
+    public void testGetSocietyPreference() throws Exception {
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -35,7 +39,6 @@ public class FrenchElectionTest {
         l1.add(s1);
         l1.add(s2);
         l1.add(s3);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(l1);
         List<Alternative> list1 = new ArrayList<>();
         List<Alternative> list2 = new ArrayList<>();
         List<Alternative> list3 = new ArrayList<>();
@@ -49,22 +52,26 @@ public class FrenchElectionTest {
         list3.add(a3);
         list3.add(a2);
         list3.add(a4);
-        OldLinearPreferenceImpl p1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
-        OldLinearPreferenceImpl p2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list2);
-        OldLinearPreferenceImpl p3 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list3);
         Voter v1 = Voter.createVoter(1);
         Voter v2 = Voter.createVoter(2);
         Voter v3 = Voter.createVoter(3);
         Voter v4 = Voter.createVoter(4);
         Voter v5 = Voter.createVoter(5);
         Voter v6 = Voter.createVoter(6);
+        LinearPreferenceImpl p1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl p1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl p1V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl p2V4 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v4, list2);
+        LinearPreferenceImpl p2V5 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v5, list2);
+        LinearPreferenceImpl p3V6 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list3);
+        CompletePreferenceImpl pref1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v1, l1);
         StrictProfileBuilder profBuild = StrictProfileBuilder.createStrictProfileBuilder();
-        profBuild.addVote(v1, p1);
-        profBuild.addVote(v2, p1);
-        profBuild.addVote(v3, p1);
-        profBuild.addVote(v4, p2);
-        profBuild.addVote(v5, p2);
-        profBuild.addVote(v6, p3);
+        profBuild.addVote(v1, p1V1);
+        profBuild.addVote(v2, p1V2);
+        profBuild.addVote(v3, p1V3);
+        profBuild.addVote(v4, p2V4);
+        profBuild.addVote(v5, p2V5);
+        profBuild.addVote(v6, p3V6);
         ImmutableStrictProfileI resultProf = (ImmutableStrictProfileI) profBuild
                         .createStrictProfileI();
         assertEquals(pref1,

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/FrenchElectionTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/analysis/FrenchElectionTest.java
@@ -13,8 +13,6 @@ import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.OldCompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.OldLinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.Voter;
-import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
-import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
 import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
 import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import io.github.oliviercailloux.j_voting.profiles.ImmutableStrictProfileI;

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ProfileBuilderTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ProfileBuilderTest.java
@@ -7,6 +7,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import io.github.oliviercailloux.j_voting.exceptions.DuplicateValueException;
+import io.github.oliviercailloux.j_voting.exceptions.EmptySetException;
+import io.github.oliviercailloux.j_voting.preferences.classes.CompletePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import org.junit.jupiter.api.Test;
 
 import io.github.oliviercailloux.j_voting.Alternative;
@@ -30,7 +34,7 @@ import io.github.oliviercailloux.j_voting.profiles.management.ProfileBuilder;
 public class ProfileBuilderTest {
 
     @Test
-    public void testCreateProfileI() {
+    public void testCreateProfileI() throws DuplicateValueException, EmptySetException {
         // ---beginning of creation of a ProfileI with ProfileBuilder
         ProfileBuilder profileBuilder = ProfileBuilder.createProfileBuilder();
         Alternative a1 = Alternative.withId(1);
@@ -58,14 +62,18 @@ public class ProfileBuilderTest {
         list1.add(s2);
         list2.add(s3);
         list2.add(s4);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
-        OldCompletePreferenceImpl pref2 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list2);
-        profileBuilder.addVote(v1, pref1);
-        profileBuilder.addVote(v2, pref1);
-        profileBuilder.addVote(v3, pref1);
-        profileBuilder.addVote(v4, pref1);
-        profileBuilder.addVote(v5, pref2);
-        profileBuilder.addVote(v6, pref2);
+        CompletePreferenceImpl pref1V1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v1, list1);
+        CompletePreferenceImpl pref1V2 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v2, list1);
+        CompletePreferenceImpl pref1V3 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v3, list1);
+        CompletePreferenceImpl pref1V4 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v4, list1);
+        CompletePreferenceImpl pref2V5 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v5, list2);
+        CompletePreferenceImpl pref2V6 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v6, list2);
+        profileBuilder.addVote(v1, pref1V1);
+        profileBuilder.addVote(v2, pref1V2);
+        profileBuilder.addVote(v3, pref1V3);
+        profileBuilder.addVote(v4, pref1V4);
+        profileBuilder.addVote(v5, pref2V5);
+        profileBuilder.addVote(v6, pref2V6);
         ProfileI immutableProfileI = profileBuilder.createProfileI();
         // ---end of creation of a ProfileI with ProfileBuilder
         ImmutableProfileI testProfileI = ImmutableProfileITest
@@ -74,7 +82,7 @@ public class ProfileBuilderTest {
     }
 
     @Test
-    public void testCreateProfile() {
+    public void testCreateProfile() throws Exception {
         // ---beginning of creation of a Profile with ProfileBuilder
         ProfileBuilder profileBuilder = ProfileBuilder.createProfileBuilder();
         Alternative a1 = Alternative.withId(1);
@@ -102,14 +110,18 @@ public class ProfileBuilderTest {
         list1.add(s2);
         list2.add(s3);
         list2.add(s4);
-        OldCompletePreferenceImpl pref1 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list1);
-        OldCompletePreferenceImpl pref2 = OldCompletePreferenceImpl.createCompletePreferenceImpl(list2);
-        profileBuilder.addVote(v1, pref1);
-        profileBuilder.addVote(v2, pref1);
-        profileBuilder.addVote(v3, pref1);
-        profileBuilder.addVote(v4, pref1);
-        profileBuilder.addVote(v5, pref2);
-        profileBuilder.addVote(v6, pref2);
+        CompletePreferenceImpl pref1V1 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v1, list1);
+        CompletePreferenceImpl pref1V2 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v2, list1);
+        CompletePreferenceImpl pref1V3 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v3, list1);
+        CompletePreferenceImpl pref1V4 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v4, list1);
+        CompletePreferenceImpl pref2V5 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v5, list2);
+        CompletePreferenceImpl pref2V6 = (CompletePreferenceImpl) CompletePreferenceImpl.asCompletePreference(v6, list2);
+        profileBuilder.addVote(v1, pref1V1);
+        profileBuilder.addVote(v2, pref1V2);
+        profileBuilder.addVote(v3, pref1V3);
+        profileBuilder.addVote(v4, pref1V4);
+        profileBuilder.addVote(v5, pref2V5);
+        profileBuilder.addVote(v6, pref2V6);
         Profile immutableProfile = profileBuilder.createProfile();
         // ---end of creation of a Profile with ProfileBuilder
         ImmutableProfile testProfile = ImmutableProfileTest.createIPToTest();
@@ -117,7 +129,7 @@ public class ProfileBuilderTest {
     }
 
     @Test
-    public void testCreateStrictProfileI() {
+    public void testCreateStrictProfileI() throws Exception {
         // ---beginning of creation of a StrictProfileI with ProfileBuilder
         ProfileBuilder profileBuilder = ProfileBuilder.createProfileBuilder();
         Alternative a1 = Alternative.withId(1);
@@ -136,14 +148,18 @@ public class ProfileBuilderTest {
         list1.add(a3);
         list2.add(a3);
         list2.add(a2);
-        OldLinearPreferenceImpl pref1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list2);
-        profileBuilder.addVote(v1, pref1);
-        profileBuilder.addVote(v2, pref1);
-        profileBuilder.addVote(v3, pref1);
-        profileBuilder.addVote(v4, pref1);
-        profileBuilder.addVote(v5, pref2);
-        profileBuilder.addVote(v6, pref2);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl pref1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl pref1V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl pref1V4 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v4, list1);
+        LinearPreferenceImpl pref2V5 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v5, list2);
+        LinearPreferenceImpl pref2V6 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list2);
+        profileBuilder.addVote(v1, pref1V1);
+        profileBuilder.addVote(v2, pref1V2);
+        profileBuilder.addVote(v3, pref1V3);
+        profileBuilder.addVote(v4, pref1V4);
+        profileBuilder.addVote(v5, pref2V5);
+        profileBuilder.addVote(v6, pref2V6);
         StrictProfileI immutableStrictProfileI = profileBuilder
                         .createStrictProfileI();
         // ---end of creation of a StrictProfileI with ProfileBuilder
@@ -153,7 +169,7 @@ public class ProfileBuilderTest {
     }
 
     @Test
-    public void testCreateStrictProfile() {
+    public void testCreateStrictProfile() throws Exception {
         // ---beginning of creation of a StrictProfile with ProfileBuilder
         ProfileBuilder profileBuilder = ProfileBuilder.createProfileBuilder();
         Alternative a1 = Alternative.withId(1);
@@ -173,14 +189,18 @@ public class ProfileBuilderTest {
         list2.add(a3);
         list2.add(a2);
         list2.add(a1);
-        OldLinearPreferenceImpl pref1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list2);
-        profileBuilder.addVote(v1, pref1);
-        profileBuilder.addVote(v2, pref1);
-        profileBuilder.addVote(v3, pref1);
-        profileBuilder.addVote(v4, pref1);
-        profileBuilder.addVote(v5, pref2);
-        profileBuilder.addVote(v6, pref2);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl pref1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl pref1V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl pref1V4 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v4, list1);
+        LinearPreferenceImpl pref2V5 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v5, list2);
+        LinearPreferenceImpl pref2V6 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list2);
+        profileBuilder.addVote(v1, pref1V1);
+        profileBuilder.addVote(v2, pref1V2);
+        profileBuilder.addVote(v3, pref1V3);
+        profileBuilder.addVote(v4, pref1V4);
+        profileBuilder.addVote(v5, pref2V5);
+        profileBuilder.addVote(v6, pref2V6);
         StrictProfile immutableStrictProfile = profileBuilder
                         .createStrictProfile();
         // ---end of creation of a StrictProfile with ProfileBuilder

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ProfileBuilderTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ProfileBuilderTest.java
@@ -34,7 +34,7 @@ import io.github.oliviercailloux.j_voting.profiles.management.ProfileBuilder;
 public class ProfileBuilderTest {
 
     @Test
-    public void testCreateProfileI() throws DuplicateValueException, EmptySetException {
+    public void testCreateProfileI() throws Exception {
         // ---beginning of creation of a ProfileI with ProfileBuilder
         ProfileBuilder profileBuilder = ProfileBuilder.createProfileBuilder();
         Alternative a1 = Alternative.withId(1);

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfileTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfileTest.java
@@ -121,7 +121,7 @@ public class ReadProfileTest {
     }
 
     @Test
-    public void testCreateProfileFromURL() throws IOException {
+    public void testCreateProfileFromURL() throws Exception {
         ReadProfile rp = new ReadProfile();
         String fileURLAsString = "https://raw.githubusercontent.com/Perciii/J-Voting/master/src/test/resources/io/github/oliviercailloux/y2018/j_voting/profiles/management/profileToRead.soc";
         ProfileI profile = rp.createProfileFromURL(new URL(fileURLAsString));

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfileTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfileTest.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import org.junit.jupiter.api.Test;
 
 import io.github.oliviercailloux.j_voting.Alternative;
@@ -21,26 +22,27 @@ import io.github.oliviercailloux.j_voting.profiles.management.StrictProfileBuild
 public class ReadProfileTest {
 
     @Test
-    public void testGetPreferences() {
+    public void testGetPreferences() throws Exception {
         ReadProfile rp = new ReadProfile();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
+        Voter v1 = Voter.createVoter(1);
         List<Alternative> alternatives = new ArrayList<>();
         alternatives.add(a1);
         alternatives.add(a2);
         alternatives.add(a3);
-        OldLinearPreferenceImpl pref = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives);
         List<Alternative> alternatives2 = new ArrayList<>();
         alternatives2.add(a2);
         alternatives2.add(a1);
         alternatives2.add(a3);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives2);
-        assertEquals(pref, rp.getPreferences(pref2, "4,1,2,3"));
+        LinearPreferenceImpl pref2V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives2);
+        assertEquals(pref1V1, rp.getPreferences(pref2V1, "4,1,2,3"));
     }
 
     @Test
-    public void testAddVotes() {
+    public void testAddVotes() throws Exception {
         StrictProfileBuilder p = StrictProfileBuilder.createStrictProfileBuilder();
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
@@ -51,13 +53,14 @@ public class ReadProfileTest {
         alternatives.add(a1);
         alternatives.add(a2);
         alternatives.add(a3);
-        OldLinearPreferenceImpl pref = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives);
-        p.addVotes(pref, 2);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives);
+        LinearPreferenceImpl pref1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, alternatives);
+        p.addVotes(pref1V1, 2);
         StrictProfileI prof = p.createStrictProfileI();
         assertTrue(prof.getProfile().containsKey(v1));
         assertTrue(prof.getProfile().containsKey(v2));
-        assertEquals(prof.getPreference(v1), pref);
-        assertEquals(prof.getPreference(v2), pref);
+        assertEquals(prof.getPreference(v1), pref1V1);
+        assertEquals(prof.getPreference(v2), pref1V1);
     }
 
     @Test
@@ -92,7 +95,7 @@ public class ReadProfileTest {
     }
 
     @Test
-    public void testCreateProfileFromStream() throws IOException {
+    public void testCreateProfileFromStream() throws Exception {
         ReadProfile rp = new ReadProfile();
         ProfileI profile = rp.createProfileFromStream(
                         getClass().getResourceAsStream("profileToRead.soc"));

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfileTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/ReadProfileTest.java
@@ -54,17 +54,16 @@ public class ReadProfileTest {
         alternatives.add(a2);
         alternatives.add(a3);
         LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives);
-        LinearPreferenceImpl pref1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, alternatives);
         p.addVotes(pref1V1, 2);
         StrictProfileI prof = p.createStrictProfileI();
         assertTrue(prof.getProfile().containsKey(v1));
         assertTrue(prof.getProfile().containsKey(v2));
-        assertEquals(prof.getPreference(v1), pref1V1);
-        assertEquals(prof.getPreference(v2), pref1V1);
+        assertEquals(prof.getPreference(v1).asList(), pref1V1.asList());
+        assertEquals(prof.getPreference(v2).asList(), pref1V1.asList());
     }
 
     @Test
-    public void testBuildProfile() {
+    public void testBuildProfile() throws Exception{
         ReadProfile rp = new ReadProfile();
         List<String> file = new ArrayList<>();
         file.add("2,1,2,3");
@@ -79,19 +78,19 @@ public class ReadProfileTest {
         alternatives.add(a1);
         alternatives.add(a2);
         alternatives.add(a3);
-        OldLinearPreferenceImpl pref = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives);
         List<Alternative> alternatives2 = new ArrayList<>();
         alternatives2.add(a3);
         alternatives2.add(a2);
         alternatives2.add(a1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives2);
-        ProfileI profile = rp.buildProfile(file, pref, 3);
+        LinearPreferenceImpl pref2V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives2);
+        ProfileI profile = rp.buildProfile(file, pref1V1, 3);
         assertTrue(profile.getProfile().containsKey(v1));
         assertTrue(profile.getProfile().containsKey(v2));
         assertTrue(profile.getProfile().containsKey(v3));
-        assertEquals(profile.getPreference(v1), pref);
-        assertEquals(profile.getPreference(v2), pref);
-        assertEquals(profile.getPreference(v3), pref2);
+        assertEquals(profile.getPreference(v1).getAlternatives(), pref1V1.getAlternatives());
+        assertEquals(profile.getPreference(v2).getAlternatives(), pref1V1.getAlternatives());
+        assertEquals(profile.getPreference(v3).getAlternatives(), pref2V1.getAlternatives());
     }
 
     @Test
@@ -109,18 +108,18 @@ public class ReadProfileTest {
         alternatives.add(a1);
         alternatives.add(a2);
         alternatives.add(a3);
-        OldLinearPreferenceImpl pref = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives);
         List<Alternative> alternatives2 = new ArrayList<>();
         alternatives2.add(a3);
         alternatives2.add(a2);
         alternatives2.add(a1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives2);
+        LinearPreferenceImpl pref2V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives2);
         assertTrue(profile.getProfile().containsKey(v1));
         assertTrue(profile.getProfile().containsKey(v2));
         assertTrue(profile.getProfile().containsKey(v3));
-        assertEquals(profile.getPreference(v1), pref);
-        assertEquals(profile.getPreference(v2), pref);
-        assertEquals(profile.getPreference(v3), pref2);
+        assertEquals(profile.getPreference(v1).getAlternatives(), pref1V1.getAlternatives());
+        assertEquals(profile.getPreference(v2).getAlternatives(), pref1V1.getAlternatives());
+        assertEquals(profile.getPreference(v3).getAlternatives(), pref2V1.getAlternatives());
     }
 
     @Test
@@ -138,17 +137,17 @@ public class ReadProfileTest {
         alternatives.add(a1);
         alternatives.add(a2);
         alternatives.add(a3);
-        OldLinearPreferenceImpl pref = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives);
         List<Alternative> alternatives2 = new ArrayList<>();
         alternatives2.add(a3);
         alternatives2.add(a2);
         alternatives2.add(a1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(alternatives2);
+        LinearPreferenceImpl pref2V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, alternatives2);
         assertTrue(profile.getProfile().containsKey(v1));
         assertTrue(profile.getProfile().containsKey(v2));
         assertTrue(profile.getProfile().containsKey(v3));
-        assertEquals(profile.getPreference(v1), pref);
-        assertEquals(profile.getPreference(v2), pref);
-        assertEquals(profile.getPreference(v3), pref2);
+        assertEquals(profile.getPreference(v1).getAlternatives(), pref1V1.getAlternatives());
+        assertEquals(profile.getPreference(v2).getAlternatives(), pref1V1.getAlternatives());
+        assertEquals(profile.getPreference(v3).getAlternatives(), pref2V1.getAlternatives());
     }
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/StrictProfileBuilderTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/profiles/management/StrictProfileBuilderTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.github.oliviercailloux.j_voting.preferences.classes.LinearPreferenceImpl;
 import org.junit.jupiter.api.Test;
 
 import io.github.oliviercailloux.j_voting.Alternative;
@@ -18,7 +19,7 @@ import io.github.oliviercailloux.j_voting.profiles.management.StrictProfileBuild
 public class StrictProfileBuilderTest {
 
     @Test
-    public void testCreateOneAlternativeProfile() {
+    public void testCreateOneAlternativeProfile() throws Exception {
         Alternative a1 = Alternative.withId(1);
         Alternative a2 = Alternative.withId(2);
         Alternative a3 = Alternative.withId(3);
@@ -36,40 +37,46 @@ public class StrictProfileBuilderTest {
         list3.add(a3);
         list3.add(a2);
         list3.add(a4);
-        OldLinearPreferenceImpl p1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list1);
-        OldLinearPreferenceImpl p2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list2);
-        OldLinearPreferenceImpl p3 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(list3);
         Voter v1 = Voter.createVoter(1);
         Voter v2 = Voter.createVoter(2);
         Voter v3 = Voter.createVoter(3);
         Voter v4 = Voter.createVoter(4);
         Voter v5 = Voter.createVoter(5);
         Voter v6 = Voter.createVoter(6);
+        LinearPreferenceImpl pref1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, list1);
+        LinearPreferenceImpl pref1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, list1);
+        LinearPreferenceImpl pref1V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, list1);
+        LinearPreferenceImpl pref2V4 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v4, list2);
+        LinearPreferenceImpl pref2V5 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v5, list2);
+        LinearPreferenceImpl pref3V6 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, list3);
         StrictProfileBuilder profBuild = StrictProfileBuilder.createStrictProfileBuilder();
-        profBuild.addVote(v1, p1);
-        profBuild.addVote(v2, p1);
-        profBuild.addVote(v3, p1);
-        profBuild.addVote(v4, p2);
-        profBuild.addVote(v5, p2);
-        profBuild.addVote(v6, p3);
+        profBuild.addVote(v1, pref1V1);
+        profBuild.addVote(v2, pref1V2);
+        profBuild.addVote(v3, pref1V3);
+        profBuild.addVote(v4, pref2V4);
+        profBuild.addVote(v5, pref2V5);
+        profBuild.addVote(v6, pref3V6);
         ImmutableStrictProfileI resultProf = profBuild
                         .createOneAlternativeProfile();
-        Map<Voter, OldLinearPreferenceImpl> map = new HashMap<>();
+        Map<Voter, LinearPreferenceImpl> map = new HashMap<>();
         List<Alternative> l1 = new ArrayList<>();
         List<Alternative> l2 = new ArrayList<>();
         List<Alternative> l3 = new ArrayList<>();
         l1.add(a1);
         l2.add(a2);
         l3.add(a3);
-        OldLinearPreferenceImpl pref1 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(l1);
-        OldLinearPreferenceImpl pref2 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(l2);
-        OldLinearPreferenceImpl pref3 = OldLinearPreferenceImpl.createStrictCompletePreferenceImpl(l3);
-        map.put(v1, pref1);
-        map.put(v2, pref1);
-        map.put(v3, pref1);
-        map.put(v4, pref2);
-        map.put(v5, pref2);
-        map.put(v6, pref3);
+        LinearPreferenceImpl p1V1 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v1, l1);
+        LinearPreferenceImpl p1V2 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v2, l1);
+        LinearPreferenceImpl p1V3 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v3, l1);
+        LinearPreferenceImpl p2V4 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v4, l2);
+        LinearPreferenceImpl p2V5 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v5, l2);
+        LinearPreferenceImpl p3V6 = (LinearPreferenceImpl) LinearPreferenceImpl.asLinearPreference(v6, l3);
+        map.put(v1, p1V1);
+        map.put(v2, p1V2);
+        map.put(v3, p1V3);
+        map.put(v4, p2V4);
+        map.put(v5, p2V5);
+        map.put(v6, p3V6);
         ImmutableStrictProfileI profile = ImmutableStrictProfileI.createImmutableStrictProfileI(map);
         assertEquals(resultProf, profile);
     }


### PR DESCRIPTION
Bonjour Monsieur,

Au terme de cette itération, le projet ne repose plus sur OldCompletePreferenceImpl et OldLinearPreferenceImpl. De plus, l'ensemble des tests du projet fonctionnent avec ce changement. 
Cependant, le prix à payer a été lourd : Gestion difficile des EmptySetExec et DuplicateValueEx lancées par la nouvelle CPI et LPI (Pour try catch obligatoires nous avons essayé au maximum de re-throw les exceptions), problèmes liés aux anciennes préférences manipulées indépendamment du Voter et remise en cause de notion d'égalité entre deux instances de préférences (Puisqu'il y a maintenant un voter stocké dans CPI et LPI) et lisibilité du code...

Enfin, face à l'utilité faible de cette tâche nous avons décidé de ne pas la poursuivre dans le futur et de se concentrer sur notre GUI.
Dev : Jade & Julien
SM/PO : Pierre 
