### PR TITLE
Mutable linear preference v2

### DIFF
--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -1,0 +1,98 @@
+package io.github.oliviercailloux.j_voting.preferences.classes;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.graph.Graph;
+import com.google.common.graph.Graphs;
+import com.google.common.graph.MutableGraph;
+
+import io.github.oliviercailloux.j_voting.Alternative;
+import io.github.oliviercailloux.j_voting.Voter;
+
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreference;
+
+import java.util.Objects;
+
+public class MutableLinearPreferenceImpl implements MutableLinearPreference{
+
+	protected Voter voter;
+    protected MutableGraph<Alternative> graph;
+    protected Set<Alternative> alternatives;
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(MutableLinearPreferenceImpl.class.getName());
+    
+    private MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
+    	this.voter = voter;
+    	graph = prefGraph; 
+    	alternatives = graph.nodes();
+    }
+
+    
+    @Override
+	public Set<Alternative> changeOrder(Set<Alternative> alternatives) {
+		
+		return null;
+	}
+
+	@Override
+	public void deleteAlternative(Alternative a) {
+		LOGGER.debug("MutablePreferenceImpl addAlternative");
+        Preconditions.checkNotNull(a);
+        graph.removeNode(a);
+		
+	}
+	
+	@Override
+	public MutableGraph<Alternative> asMutableGraph() {
+		return graph;
+	}
+
+	@Override
+	public void addAlternative(Alternative alternative) {
+		
+		
+	}
+
+	@Override
+	public void addEquivalence(Alternative a1, Alternative a2) {
+		
+		
+	}
+
+	@Override
+	public void setAsLeastAsGood(Alternative a1, Alternative a2) {
+		
+		
+	}
+
+	@Override
+	public Graph<Alternative> asGraph() {
+		return graph;
+		
+		
+	}
+
+	@Override
+	public Set<Alternative> getAlternatives() {
+		return alternatives;
+		
+	}
+
+	@Override
+	public Voter getVoter() {
+	
+		return null;
+	}
+
+	
+    
+	
+   
+	
+	
+}

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -70,7 +70,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     	Preconditions.checkNotNull(newGraph);
     	boolean testComplete = true;
     	for (Alternative a : newGraph.nodes()) {
-    		if (testComplete == false)
+    		if (!testComplete)
     			throw new IllegalArgumentException("There are no edges between all alternatives");
     		if (newGraph.successors(a).size() == 0)
     			testComplete = false;

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -23,148 +23,147 @@ import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPr
 public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 
 	protected Voter voter;
-    protected MutableGraph<Alternative> graph;
-    protected Set<Alternative> alternatives;
-    protected LinkedList<Alternative> list;
-    protected ImmutableGraph<Alternative> delegate;
-    
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(MutableLinearPreferenceImpl.class.getName());
-    
-    private MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
-    	this.voter = voter;
-    	this.graph = prefGraph; 
-    	this.alternatives = graph.nodes();
-    	this.list = new LinkedList<>();
-    	
-    	Iterator<Alternative> itSet = alternatives.iterator();
+	protected MutableGraph<Alternative> graph;
+	protected Set<Alternative> alternatives;
+	protected LinkedList<Alternative> list;
+	protected ImmutableGraph<Alternative> delegate;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MutableLinearPreferenceImpl.class.getName());
+
+	private MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
+		this.voter = voter;
+		this.graph = prefGraph;
+		this.alternatives = graph.nodes();
+		this.list = new LinkedList<>();
+
+		Iterator<Alternative> itSet = alternatives.iterator();
 		while (itSet.hasNext() == true) {
 			list.add(itSet.next());
 		}
-    }
-    
-    /**
-     * @param prefGraph is a mutable graph of alternatives representing the
-     *              preference. This graph has no cycle.
-     * @param voter is the Voter associated to the Preference.
-     * @return the mutable linear preference
-     */
-    public static MutableLinearPreference given(Voter voter, MutableGraph<Alternative> prefGraph) {
-    	LOGGER.debug("MutableLinearPreferenceImpl given");
-    	Preconditions.checkNotNull(voter);
-    	Preconditions.checkNotNull(prefGraph);
+	}
 
-    	for (Alternative a : prefGraph.nodes()) {    			
-    		if ((prefGraph.successors(a).size() == 0) && (prefGraph.predecessors(a).size() == 0)) 
-    			throw new IllegalArgumentException("There are no edges between all alternatives");
-    	}
-    	for (Alternative a1 : prefGraph.nodes()) {
-            for (Alternative a2 : prefGraph.successors(a1)) {
-                if (Graphs.transitiveClosure(prefGraph).hasEdgeConnecting(a2,a1) && !a2.equals(a1)) {
-                    throw new IllegalArgumentException("The alternatives " + a1 + " and " + a2 + " cannot be ex-eaquo.");
-                }
-            }
-        }
-    	return new MutableLinearPreferenceImpl(voter, prefGraph);
-    }
-    
-    private MutableLinearPreferenceImpl(Voter voter, LinkedList<Alternative> list) {
-    	this.voter = voter;
-    	this.list = list;
-    	this.graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+	/**
+	 * @param prefGraph is a mutable graph of alternatives representing the
+	 *                  preference. This graph has no cycle.
+	 * @param voter     is the Voter associated to the Preference.
+	 * @return the mutable linear preference
+	 */
+	public static MutableLinearPreference given(Voter voter, MutableGraph<Alternative> prefGraph) {
+		LOGGER.debug("MutableLinearPreferenceImpl given");
+		Preconditions.checkNotNull(voter);
+		Preconditions.checkNotNull(prefGraph);
 
-    	Iterator<Alternative> itList = list.iterator();
-    	Alternative a = itList.next();
-    	Alternative a2;
+		for (Alternative a : prefGraph.nodes()) {
+			if ((prefGraph.successors(a).size() == 0) && (prefGraph.predecessors(a).size() == 0))
+				throw new IllegalArgumentException("There are no edges between all alternatives");
+		}
+		for (Alternative a1 : prefGraph.nodes()) {
+			for (Alternative a2 : prefGraph.successors(a1)) {
+				if (Graphs.transitiveClosure(prefGraph).hasEdgeConnecting(a2, a1) && !a2.equals(a1)) {
+					throw new IllegalArgumentException(
+							"The alternatives " + a1 + " and " + a2 + " cannot be ex-eaquo.");
+				}
+			}
+		}
+		return new MutableLinearPreferenceImpl(voter, prefGraph);
+	}
+
+	private MutableLinearPreferenceImpl(Voter voter, LinkedList<Alternative> list) {
+		this.voter = voter;
+		this.list = list;
+		this.graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+
+		Iterator<Alternative> itList = list.iterator();
+		Alternative a = itList.next();
+		Alternative a2;
 		while (itList.hasNext() == true) {
 			a2 = itList.next();
 			graph.putEdge(a, a2);
 			a = a2;
 		}
 		this.alternatives = graph.nodes();
-    }
-    
-    /**
-     * @param list is a LinkedList of alternatives representing the
-     *              preference.
-     * @param voter is the Voter associated to the Preference.
-     * @return the mutable linear preference
-     */
-    public static MutableLinearPreference given(Voter voter, LinkedList<Alternative> list) {
-    	LOGGER.debug("MutableLinearPreferenceImpl given");
-    	Preconditions.checkNotNull(voter);
-    	Preconditions.checkNotNull(list);
+	}
 
-    	return new MutableLinearPreferenceImpl(voter, list);
-    }
-    
-    @Override
-	public void changeOrder(Alternative alternative, int rank) {
-    	LOGGER.debug("MutableLinearPreferenceImpl changeOrder");
-    	Preconditions.checkNotNull(alternative);
-    	Preconditions.checkNotNull(rank);	
-    	    	
-    	Alternative temp;
-    	Iterator<Alternative> itTemp;
+	/**
+	 * @param list  is a LinkedList of alternatives representing the preference.
+	 * @param voter is the Voter associated to the Preference.
+	 * @return the mutable linear preference
+	 */
+	public static MutableLinearPreference given(Voter voter, LinkedList<Alternative> list) {
+		LOGGER.debug("MutableLinearPreferenceImpl given");
+		Preconditions.checkNotNull(voter);
+		Preconditions.checkNotNull(list);
 
-    	int initRank = list.indexOf(alternative);   	
-    	if (initRank - rank > 0) { //swap à gauche
-    		for(int i = initRank; i > rank; i-- ) {
-    			itTemp = graph.predecessors(alternative).iterator();
-        		temp = itTemp.next();
-        		swap(temp,alternative);
-    		}
-		} 
-    	else if (initRank - rank < 0) { //swap à droite
-    		for(int i = initRank; i < rank; i++ ) {
-    			itTemp = graph.successors(alternative).iterator();
-        		temp = itTemp.next();
-        		swap(alternative,temp);
-    		}
-    	}
+		return new MutableLinearPreferenceImpl(voter, list);
 	}
 
 	@Override
-	public void deleteAlternative(Alternative a) {	
-		LOGGER.debug("MutableLinearPreferenceImpl deleteAlternative");
-        Preconditions.checkNotNull(a);
+	public void changeOrder(Alternative alternative, int rank) {
+		LOGGER.debug("MutableLinearPreferenceImpl changeOrder");
+		Preconditions.checkNotNull(alternative);
+		Preconditions.checkNotNull(rank);
 
-        if ((graph.successors(a).size() != 0) && (graph.predecessors(a).size() != 0)) {	
-        	Set<Alternative> setPred = graph.predecessors(a);
-    		Iterator<Alternative> itPred = setPred.iterator();
-    		Alternative pred = itPred.next();
-    				
-    		Set<Alternative> setSucc = graph.successors(a);
-    		Iterator<Alternative> itSucc = setSucc.iterator();
-    		if (itSucc.hasNext() == true) 
-    			graph.putEdge(pred,  itSucc.next());
+		Alternative temp;
+		Iterator<Alternative> itTemp;
+
+		int initRank = list.indexOf(alternative);
+		if (initRank - rank > 0) { // swap à gauche
+			for (int i = initRank; i > rank; i--) {
+				itTemp = graph.predecessors(alternative).iterator();
+				temp = itTemp.next();
+				swap(temp, alternative);
+			}
+		} else if (initRank - rank < 0) { // swap à droite
+			for (int i = initRank; i < rank; i++) {
+				itTemp = graph.successors(alternative).iterator();
+				temp = itTemp.next();
+				swap(alternative, temp);
+			}
 		}
-            
-        graph.removeNode(a);
-        list.remove(a);
 	}
-	
+
+	@Override
+	public void deleteAlternative(Alternative a) {
+		LOGGER.debug("MutableLinearPreferenceImpl deleteAlternative");
+		Preconditions.checkNotNull(a);
+
+		if ((graph.successors(a).size() != 0) && (graph.predecessors(a).size() != 0)) {
+			Set<Alternative> setPred = graph.predecessors(a);
+			Iterator<Alternative> itPred = setPred.iterator();
+			Alternative pred = itPred.next();
+
+			Set<Alternative> setSucc = graph.successors(a);
+			Iterator<Alternative> itSucc = setSucc.iterator();
+			if (itSucc.hasNext() == true)
+				graph.putEdge(pred, itSucc.next());
+		}
+
+		graph.removeNode(a);
+		list.remove(a);
+	}
+
 	@Override
 	public void addAlternative(Alternative a) {
 		LOGGER.debug("MutablePreferenceImpl addAlternative");
-        Preconditions.checkNotNull(a);
-        
-        for (Alternative ai : graph.nodes()) {
-        	if (graph.successors(ai).size() == 0) {
-    			graph.putEdge(ai, a);        		
-        	}
-    	}
-        list.add(a);
+		Preconditions.checkNotNull(a);
+
+		for (Alternative ai : graph.nodes()) {
+			if (graph.successors(ai).size() == 0) {
+				graph.putEdge(ai, a);
+			}
+		}
+		list.add(a);
 	}
-	
+
 	/**
-     * @return an immutable set of all alternatives of the preference
-     * 
-     */
+	 * @return an immutable set of all alternatives of the preference
+	 * 
+	 */
 	@Override
-	public Set<Alternative> getAlternatives() {	
-		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");	
-		Preconditions.checkState(!(alternatives.size() != graph.nodes().size() || !(alternatives.containsAll(graph.nodes()))),
+	public Set<Alternative> getAlternatives() {
+		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");
+		Preconditions.checkState(
+				!(alternatives.size() != graph.nodes().size() || !(alternatives.containsAll(graph.nodes()))),
 				"An alternative must not be deleted from the set");
 		return MutableLinearSetDecorator.given(alternatives);
 	}
@@ -173,7 +172,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	public Voter getVoter() {
 		return voter;
 	}
-	
+
 	@Override
 	public Graph<Alternative> asGraph() {
 		return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
@@ -185,85 +184,85 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		Preconditions.checkNotNull(alternative1);
 		Preconditions.checkNotNull(alternative2);
 		Preconditions.checkArgument(!alternative1.equals(alternative2), "The alternatives must be differents.");
-		
+
 		boolean neighbour = false;
 		Alternative a1 = alternative1;
-		Alternative a2 = alternative2; 
-				
-		if(list.indexOf(alternative1) > list.indexOf(alternative2)) {
+		Alternative a2 = alternative2;
+
+		if (list.indexOf(alternative1) > list.indexOf(alternative2)) {
 			a1 = alternative2;
 			a2 = alternative1;
-		} 
-		
-		if(list.indexOf(alternative2) - list.indexOf(alternative1) == 1) 
+		}
+
+		if (list.indexOf(alternative2) - list.indexOf(alternative1) == 1)
 			neighbour = true;
-		
+
 		Alternative pred1 = null;
 		Alternative pred2 = null;
 		Alternative succ1 = null;
 		Alternative succ2 = null;
-		
+
 		Set<Alternative> setSucc1 = graph.successors(a1);
 		Iterator<Alternative> itSucc1 = setSucc1.iterator();
-		if (itSucc1.hasNext() == true) 
+		if (itSucc1.hasNext() == true)
 			succ1 = itSucc1.next();
-		
+
 		Set<Alternative> setSucc2 = graph.successors(a2);
 		Iterator<Alternative> itSucc2 = setSucc2.iterator();
-		if (itSucc2.hasNext() == true) 
+		if (itSucc2.hasNext() == true)
 			succ2 = itSucc2.next();
-		
+
 		Set<Alternative> setPred1 = graph.predecessors(a1);
 		Iterator<Alternative> itPred1 = setPred1.iterator();
-		if (itPred1.hasNext() == true) 
+		if (itPred1.hasNext() == true)
 			pred1 = itPred1.next();
-				
+
 		Set<Alternative> setPred2 = graph.predecessors(a2);
 		Iterator<Alternative> itPred2 = setPred2.iterator();
-		if (itPred2.hasNext() == true) 
-			pred2 = itPred2.next();		
-		
+		if (itPred2.hasNext() == true)
+			pred2 = itPred2.next();
+
 		graph.removeNode(a1);
 		graph.removeNode(a2);
-		
-		if(neighbour) {
-			if (a1.equals(list.getFirst())) {    
-				if (a2.equals(list.getLast())) {              //swap(head, end)	 dans le cas ou il y a seulement 2 alternatives                                 
+
+		if (neighbour) {
+			if (a1.equals(list.getFirst())) {
+				if (a2.equals(list.getLast())) { // swap(head, end) dans le cas ou il y a seulement 2 alternatives
 					graph.putEdge(a2, a1);
-				} else {                                      //swap(head, middle)
+				} else { // swap(head, middle)
 					graph.putEdge(a2, a1);
 					graph.putEdge(a1, succ2);
 				}
-			} else if (a2.equals(list.getLast())) {           //swap(middle,end)
+			} else if (a2.equals(list.getLast())) { // swap(middle,end)
 				graph.putEdge(pred1, a2);
 				graph.putEdge(a2, a1);
-			} else {                                          //swap(middle,middle)
+			} else { // swap(middle,middle)
 				graph.putEdge(pred1, a2);
 				graph.putEdge(a2, a1);
 				graph.putEdge(a1, succ2);
 			}
 		} else {
-			if (a1.equals(list.getFirst())) {    
-				if (a2.equals(list.getLast())) {              //swap(head, end)                                 
+			if (a1.equals(list.getFirst())) {
+				if (a2.equals(list.getLast())) { // swap(head, end)
 					graph.putEdge(a2, succ1);
 					graph.putEdge(pred2, a1);
-				} else {                                      //swap(head, middle)
+				} else { // swap(head, middle)
 					graph.putEdge(a2, succ1);
 					graph.putEdge(pred2, a1);
 					graph.putEdge(a1, succ2);
 				}
-			} else if (a2.equals(list.getLast())) {           //swap(middle,end)
+			} else if (a2.equals(list.getLast())) { // swap(middle,end)
 				graph.putEdge(pred1, a2);
-				graph.putEdge(a2,succ1);
-				graph.putEdge(pred2,a1);
-			} else {                                          //swap(middle,middle)
+				graph.putEdge(a2, succ1);
+				graph.putEdge(pred2, a1);
+			} else { // swap(middle,middle)
 				graph.putEdge(pred1, a2);
-				graph.putEdge(a2,succ1);
-				graph.putEdge(pred2,a1);
-				graph.putEdge(a1,succ2);
+				graph.putEdge(a2, succ1);
+				graph.putEdge(pred2, a1);
+				graph.putEdge(a1, succ2);
 			}
-		}		
-	    Collections.swap(list,list.indexOf(alternative1),list.indexOf(alternative2));
+		}
+		Collections.swap(list, list.indexOf(alternative1), list.indexOf(alternative2));
 	}
 
 	@Override
@@ -308,5 +307,5 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 			return false;
 		return true;
 	}
-	
+
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -44,10 +44,13 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     	boolean testComplete = true;
     	for (Alternative a : prefGraph.nodes()) {
     		if (testComplete == false)
-    			throw new IllegalArgumentException("The preference is not complete");
-    		if (prefGraph.successors(a) == null)
+    			throw new IllegalArgumentException("There are no edges between all alternatives");
+    		if (prefGraph.successors(a).size() == 0)
     			testComplete = false;
     	}
+    	
+    	if (Graphs.hasCycle(prefGraph))
+			throw new IllegalArgumentException("The preference has a cycle");
     		
     	for (Alternative a1 : prefGraph.nodes()) {
             for (Alternative a2 : prefGraph.successors(a1)) {
@@ -82,6 +85,10 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 		LOGGER.debug("MutablePreferenceImpl addAlternative");
         Preconditions.checkNotNull(a);
         graph.addNode(a);
+        for (Alternative ai : graph.nodes()) {
+        	if (graph.successors(a).size() == 0)
+    			graph.putEdge(ai, a);
+    	}
 		
 	}
 

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -74,6 +74,25 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     	LOGGER.debug("MutableLinearPreferenceImpl changeOrder");
     	Preconditions.checkNotNull(alternative);
     	Preconditions.checkNotNull(rank);	
+    	    	
+    	Alternative temp;
+    	Iterator<Alternative> itTemp;
+
+    	int initRank = list.indexOf(alternative);   	
+    	if (initRank - rank > 0) { //swap à gauche
+    		for(int i = initRank; i > rank; i-- ) {
+    			itTemp = graph.predecessors(alternative).iterator();
+        		temp = itTemp.next();
+        		swap(temp,alternative);
+    		}
+		} 
+    	else if (initRank - rank < 0) { //swap à droite
+    		for(int i = initRank; i < rank; i++ ) {
+    			itTemp = graph.successors(alternative).iterator();
+        		temp = itTemp.next();
+        		swap(alternative,temp);
+    		}
+    	}
 	}
 
 	@Override
@@ -141,74 +160,83 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		if(alternative1.equals(alternative2)) 
 			throw new IllegalArgumentException("The alternatives must be differents.");
 		
+		boolean neighbour = false;
+		Alternative a1 = alternative1;
+		Alternative a2 = alternative2; 
+				
+		if(list.indexOf(alternative1) > list.indexOf(alternative2)) {
+			a1 = alternative2;
+			a2 = alternative1;
+		} 
+		
+		if(list.indexOf(alternative2) - list.indexOf(alternative1) == 1) 
+			neighbour = true;
+		
 		Alternative pred1 = null;
 		Alternative pred2 = null;
 		Alternative succ1 = null;
 		Alternative succ2 = null;
 		
-		Set<Alternative> setSucc1 = graph.successors(alternative1);
+		Set<Alternative> setSucc1 = graph.successors(a1);
 		Iterator<Alternative> itSucc1 = setSucc1.iterator();
 		if (itSucc1.hasNext() == true) 
 			succ1 = itSucc1.next();
 		
-		Set<Alternative> setSucc2 = graph.successors(alternative2);
+		Set<Alternative> setSucc2 = graph.successors(a2);
 		Iterator<Alternative> itSucc2 = setSucc2.iterator();
 		if (itSucc2.hasNext() == true) 
 			succ2 = itSucc2.next();
 		
-		Set<Alternative> setPred1 = graph.predecessors(alternative1);
+		Set<Alternative> setPred1 = graph.predecessors(a1);
 		Iterator<Alternative> itPred1 = setPred1.iterator();
 		if (itPred1.hasNext() == true) 
 			pred1 = itPred1.next();
 				
-		Set<Alternative> setPred2 = graph.predecessors(alternative2);
+		Set<Alternative> setPred2 = graph.predecessors(a2);
 		Iterator<Alternative> itPred2 = setPred2.iterator();
 		if (itPred2.hasNext() == true) 
 			pred2 = itPred2.next();		
 		
-		graph.removeNode(alternative1);
-		graph.removeNode(alternative2);
+		graph.removeNode(a1);
+		graph.removeNode(a2);
 		
-		if (alternative1.equals(list.getFirst())) {		
-			if(alternative2.equals(list.getLast())) {				
-				graph.putEdge(alternative2, succ1);
-				graph.putEdge(pred2, alternative1);			
-			} 
-			else {
-				graph.putEdge(alternative2, succ1);
-				graph.putEdge(pred2, alternative1);
-				graph.putEdge(alternative1,succ2);				
+		if(neighbour) {
+			if (a1.equals(list.getFirst())) {    
+				if (a2.equals(list.getLast())) {              //swap(head, end)	 dans le cas ou il y a seulement 2 alternatives                                 
+					graph.putEdge(a2, a1);
+				} else {                                      //swap(head, middle)
+					graph.putEdge(a2, a1);
+					graph.putEdge(a1, succ2);
+				}
+			} else if (a2.equals(list.getLast())) {           //swap(middle,end)
+				graph.putEdge(pred1, a2);
+				graph.putEdge(a2, a1);
+			} else {                                          //swap(middle,middle)
+				graph.putEdge(pred1, a2);
+				graph.putEdge(a2, a1);
+				graph.putEdge(a1, succ2);
 			}
-		} 
-		else if (alternative1.equals(list.getLast())) {	
-			if(alternative2 == list.getFirst()) {				
-				graph.putEdge(pred1,alternative2);
-				graph.putEdge(alternative1,succ2);			
-			} 
-			else {					
-				graph.putEdge(pred2,alternative1);
-				graph.putEdge(alternative1,succ2);
-				graph.putEdge(pred1,alternative2);
+		} else {
+			if (a1.equals(list.getFirst())) {    
+				if (a2.equals(list.getLast())) {              //swap(head, end)                                 
+					graph.putEdge(a2, succ1);
+					graph.putEdge(pred2, a1);
+				} else {                                      //swap(head, middle)
+					graph.putEdge(a2, succ1);
+					graph.putEdge(pred2, a1);
+					graph.putEdge(a1, succ2);
+				}
+			} else if (a2.equals(list.getLast())) {           //swap(middle,end)
+				graph.putEdge(pred1, a2);
+				graph.putEdge(a2,succ1);
+				graph.putEdge(pred2,a1);
+			} else {                                          //swap(middle,middle)
+				graph.putEdge(pred1, a2);
+				graph.putEdge(a2,succ1);
+				graph.putEdge(pred2,a1);
+				graph.putEdge(a1,succ2);
 			}
-		} 
-		else {		
-			if(alternative2 == list.getLast()) {			
-				graph.putEdge(pred1,alternative2);
-				graph.putEdge(alternative2,succ1);
-				graph.putEdge(pred2,alternative1);	
-			} 
-			else if (alternative2 == list.getFirst()) {
-				graph.putEdge(pred1,alternative2);
-				graph.putEdge(alternative2,succ1);
-				graph.putEdge(alternative1,succ2);	
-			} 
-			else {
-				graph.putEdge(pred2,alternative1);
-				graph.putEdge(alternative1,succ2);
-				graph.putEdge(pred1,alternative2);
-				graph.putEdge(alternative2,succ1);
-			}		
-		}
+		}		
 	    Collections.swap(list,list.indexOf(alternative1),list.indexOf(alternative2));
 	}
 

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -1,6 +1,8 @@
 package io.github.oliviercailloux.j_voting.preferences.classes;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -24,6 +26,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	protected Voter voter;
     protected MutableGraph<Alternative> graph;
     protected Set<Alternative> alternatives;
+    protected LinkedList<Alternative> list;
     
     private static final Logger LOGGER = LoggerFactory
             .getLogger(MutableLinearPreferenceImpl.class.getName());
@@ -68,31 +71,11 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     }
     
     @Override
-	public void changeOrder(MutableGraph<Alternative> newGraph) {
+	public void changeOrder(Alternative alternative, int rank) {
     	LOGGER.debug("MutableLinearPreferenceImpl changeOrder");
-    	Preconditions.checkNotNull(newGraph);
-    	boolean testComplete = true;
-    	for (Alternative a : newGraph.nodes()) {
-    		if (!testComplete)
-    			throw new IllegalArgumentException("There are no edges between all alternatives");
-    		if (newGraph.successors(a).size() == 0)
-    			testComplete = false;
-    	}
-    	
-    	if (Graphs.hasCycle(newGraph))
-			throw new IllegalArgumentException("The preference has a cycle");
-    		
-    	for (Alternative a1 : newGraph.nodes()) {
-            for (Alternative a2 : newGraph.successors(a1)) {
-                if (Graphs.transitiveClosure(newGraph).hasEdgeConnecting(a2,
-                                a1) && !a2.equals(a1)) {
-                    throw new IllegalArgumentException("The alternatives " + a1
-                                    + " and " + a2 + " cannot be ex-eaquo.");
-                }
-            }
-        }
-    	graph = newGraph;
-    	alternatives = newGraph.nodes();
+    	Preconditions.checkNotNull(alternative);
+    	Preconditions.checkNotNull(rank);	
+  
 	}
 
 	@Override
@@ -100,6 +83,8 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		LOGGER.debug("MutableLinearPreferenceImpl deleteAlternative");
         Preconditions.checkNotNull(a);
         graph.removeNode(a);	
+        
+        alternatives = graph.nodes();
 	}
 	
 	@Override
@@ -111,6 +96,8 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
         	if (graph.successors(a).size() == 0)
     			graph.putEdge(ai, a);
     	}
+        
+        alternatives = graph.nodes();
 	}
 	
 	/**
@@ -137,32 +124,63 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	}
 
 	@Override
-	public void reverse(Alternative alternative1, Alternative alternative2) {
-		LOGGER.debug("MutablePreferenceImpl reverse");
+	public void swap(Alternative alternative1, Alternative alternative2) {
+		LOGGER.debug("MutablePreferenceImpl Swap");
 		Preconditions.checkNotNull(alternative1);
 		Preconditions.checkNotNull(alternative2);
 		
-		Set<Alternative> set = new HashSet<>();
-		set.add(alternative1);
-		set.add(alternative2);
-		
-		for(Alternative a : set) {
-			Set<Alternative> predecessor = graph.predecessors(a);
-			Set<Alternative> successor = graph.successors(a);
-			
-			graph.removeNode(a);
-			
-			for(Alternative p : predecessor) {
-				graph.putEdge(p, a);
-			}
-			
-			for(Alternative s : successor) {
-				graph.putEdge(a, s);
-			}
-			
-		}
-			
-		alternatives = graph.nodes();
+		if(alternative1.equals(alternative2)) 
+			throw new IllegalArgumentException("The alternatives " + alternative1  + " and " + alternative2 + " must be differents.");
 
+		Alternative pred1 = (Alternative)graph.predecessors(alternative1);
+		Alternative pred2 = (Alternative)graph.predecessors(alternative2);
+		Alternative succ1 = (Alternative)graph.successors(alternative1);
+		Alternative succ2 = (Alternative)graph.successors(alternative2);
+		
+		graph.removeNode(alternative1);
+		graph.removeNode(alternative2);
+		
+		if (alternative1.equals(list.getFirst())) {						
+			if(alternative2.equals(list.getLast())) {				
+				graph.putEdge(alternative2, succ1);
+				graph.putEdge(pred2, alternative1);			
+			} 
+			else {
+				graph.putEdge(alternative2, succ1);
+				graph.putEdge(pred2, alternative1);
+				graph.putEdge(alternative1,succ2);				
+			}
+		} 
+		else if (alternative1.equals(list.getLast())) {	
+			if(alternative2 == list.getFirst()) {				
+				graph.putEdge(pred1,alternative2);
+				graph.putEdge(alternative1,succ2);			
+			} 
+			else {					
+				graph.putEdge(pred2,alternative1);
+				graph.putEdge(alternative1,succ2);
+				graph.putEdge(pred1,alternative2);
+			}
+		} 
+		else {		
+			if(alternative2 == list.getLast()) {			
+				graph.putEdge(pred1,alternative2);
+				graph.putEdge(alternative2,succ1);
+				graph.putEdge(pred2,alternative1);	
+			} 
+			else if (alternative2 == list.getFirst()) {
+				graph.putEdge(pred1,alternative2);
+				graph.putEdge(alternative2,succ1);
+				graph.putEdge(alternative1,succ2);	
+			} 
+			else {
+				graph.putEdge(pred2,alternative1);
+				graph.putEdge(alternative1,succ2);
+				graph.putEdge(pred1,alternative2);
+				graph.putEdge(alternative2,succ1);
+			}		
+		}
+		
+	    Collections.swap(list,list.indexOf(alternative1),list.indexOf(alternative2));
 	}	
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -68,6 +68,26 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 	public void changeOrder(MutableGraph<Alternative> newGraph) {
     	LOGGER.debug("MutableLinearPreferenceImpl changeOrder");
     	Preconditions.checkNotNull(newGraph);
+    	boolean testComplete = true;
+    	for (Alternative a : newGraph.nodes()) {
+    		if (testComplete == false)
+    			throw new IllegalArgumentException("There are no edges between all alternatives");
+    		if (newGraph.successors(a).size() == 0)
+    			testComplete = false;
+    	}
+    	
+    	if (Graphs.hasCycle(newGraph))
+			throw new IllegalArgumentException("The preference has a cycle");
+    		
+    	for (Alternative a1 : newGraph.nodes()) {
+            for (Alternative a2 : newGraph.successors(a1)) {
+                if (Graphs.transitiveClosure(newGraph).hasEdgeConnecting(a2,
+                                a1) && !a2.equals(a1)) {
+                    throw new IllegalArgumentException("The alternatives " + a1
+                                    + " and " + a2 + " cannot be ex-eaquo.");
+                }
+            }
+        }
     	graph = newGraph;
     	alternatives = newGraph.nodes();
 	}

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -176,8 +176,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	
 	@Override
 	public Graph<Alternative> asGraph() {
-		return Graphs.transitiveClosure(graph);
-		//return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
+		return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
 	}
 
 	@Override

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -6,8 +6,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.Graph;
 import com.google.common.graph.Graphs;
+import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 
 import io.github.oliviercailloux.j_voting.Alternative;
@@ -26,71 +28,65 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     private static final Logger LOGGER = LoggerFactory
             .getLogger(MutableLinearPreferenceImpl.class.getName());
     
-    private MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
+    public MutableLinearPreferenceImpl(Voter voter, MutableGraph<Alternative> prefGraph) {
     	this.voter = voter;
     	graph = prefGraph; 
     	alternatives = graph.nodes();
     }
 
+    //faire des constructeurs given ?? comme dans MutablePreference 
+    //et mettre le constructeur au dessus en private
     
     @Override
-	public Set<Alternative> changeOrder(Set<Alternative> alternatives) {
+	public Set<Alternative> changeOrder(Set<Alternative> a) {
 		
 		return null;
 	}
 
 	@Override
 	public void deleteAlternative(Alternative a) {
-		LOGGER.debug("MutablePreferenceImpl addAlternative");
+		
+		LOGGER.debug("MutableLinearPreferenceImpl addAlternative");
         Preconditions.checkNotNull(a);
         graph.removeNode(a);
 		
 	}
 	
 	@Override
-	public MutableGraph<Alternative> asMutableGraph() {
-		return graph;
-	}
-
-	@Override
-	public void addAlternative(Alternative alternative) {
-		
+	public void addAlternative(Alternative a) {
+		LOGGER.debug("MutablePreferenceImpl addAlternative");
+        Preconditions.checkNotNull(a);
+        graph.addNode(a);
 		
 	}
 
-	@Override
-	public void addEquivalence(Alternative a1, Alternative a2) {
-		
-		
-	}
-
-	@Override
-	public void setAsLeastAsGood(Alternative a1, Alternative a2) {
-		
-		
-	}
-
-	@Override
-	public Graph<Alternative> asGraph() {
-		return graph;
-		
-		
-	}
 
 	@Override
 	public Set<Alternative> getAlternatives() {
-		return alternatives;
 		
+		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");
+		
+		if (alternatives.size() != graph.nodes().size() || !(alternatives.containsAll(graph.nodes()))) {
+        	
+			throw new IllegalStateException("An alternative must not be deleted from the set");
+        }
+		
+		return ImmutableSet.copyOf(alternatives);
+        
 	}
+
 
 	@Override
 	public Voter getVoter() {
+		return voter;
+	}
 	
-		return null;
+	@Override
+	public Graph<Alternative> asGraph() {
+		return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
 	}
 
 	
-    
 	
    
 	

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -38,14 +38,10 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     	this.alternatives = graph.nodes();
     	this.list = new LinkedList<>();
     	
-    	Set<Alternative> set = prefGraph.nodes();
-    	Iterator<Alternative> itSet = set.iterator();
+    	Iterator<Alternative> itSet = alternatives.iterator();
 		while (itSet.hasNext() == true) {
 			list.add(itSet.next());
 		}
-    	
-    	
-    	
     }
     
     /**
@@ -58,23 +54,19 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     	LOGGER.debug("MutableLinearPreferenceImpl given");
     	Preconditions.checkNotNull(voter);
     	Preconditions.checkNotNull(prefGraph);
-    	boolean testComplete = true;
-    	for (Alternative a : prefGraph.nodes()) {
-    		if (!testComplete)
+
+    	for (Alternative a : prefGraph.nodes()) {    			
+    		if ((prefGraph.successors(a).size() == 0) && (prefGraph.predecessors(a).size() == 0)) 
     			throw new IllegalArgumentException("There are no edges between all alternatives");
-    		if (prefGraph.successors(a).size() == 0)
-    			testComplete = false;
     	}
-    	
+    	/*
     	if (Graphs.hasCycle(prefGraph))
 			throw new IllegalArgumentException("The preference has a cycle");
-    		
+    	*/
     	for (Alternative a1 : prefGraph.nodes()) {
             for (Alternative a2 : prefGraph.successors(a1)) {
-                if (Graphs.transitiveClosure(prefGraph).hasEdgeConnecting(a2,
-                                a1) && !a2.equals(a1)) {
-                    throw new IllegalArgumentException("The alternatives " + a1
-                                    + " and " + a2 + " cannot be ex-eaquo.");
+                if (Graphs.transitiveClosure(prefGraph).hasEdgeConnecting(a2,a1) && !a2.equals(a1)) {
+                    throw new IllegalArgumentException("The alternatives " + a1 + " and " + a2 + " cannot be ex-eaquo.");
                 }
             }
         }
@@ -86,15 +78,13 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     	LOGGER.debug("MutableLinearPreferenceImpl changeOrder");
     	Preconditions.checkNotNull(alternative);
     	Preconditions.checkNotNull(rank);	
-  
 	}
 
 	@Override
 	public void deleteAlternative(Alternative a) {	
 		LOGGER.debug("MutableLinearPreferenceImpl deleteAlternative");
         Preconditions.checkNotNull(a);
-        graph.removeNode(a);	
-        
+        graph.removeNode(a);	       
         alternatives = graph.nodes();
 	}
 	
@@ -106,8 +96,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
         for (Alternative ai : graph.nodes()) {
         	if (graph.successors(a).size() == 0)
     			graph.putEdge(ai, a);
-    	}
-        
+    	}        
         alternatives = graph.nodes();
 	}
 	
@@ -141,7 +130,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		Preconditions.checkNotNull(alternative2);
 		
 		if(alternative1.equals(alternative2)) 
-			throw new IllegalArgumentException("The alternatives " + alternative1  + " and " + alternative2 + " must be differents.");
+			throw new IllegalArgumentException("The alternatives must be differents.");
 		
 		Alternative pred1 = null;
 		Alternative pred2 = null;
@@ -150,27 +139,23 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		
 		Set<Alternative> setSucc1 = graph.successors(alternative1);
 		Iterator<Alternative> itSucc1 = setSucc1.iterator();
-		if (itSucc1.hasNext() == true) {
+		if (itSucc1.hasNext() == true) 
 			succ1 = itSucc1.next();
-		}
-
+		
 		Set<Alternative> setSucc2 = graph.successors(alternative2);
 		Iterator<Alternative> itSucc2 = setSucc2.iterator();
-		if (itSucc2.hasNext() == true) {
+		if (itSucc2.hasNext() == true) 
 			succ2 = itSucc2.next();
-		}
 		
 		Set<Alternative> setPred1 = graph.predecessors(alternative1);
 		Iterator<Alternative> itPred1 = setPred1.iterator();
-		if (itPred1.hasNext() == true) {
+		if (itPred1.hasNext() == true) 
 			pred1 = itPred1.next();
-		}
-		
+				
 		Set<Alternative> setPred2 = graph.predecessors(alternative2);
 		Iterator<Alternative> itPred2 = setPred2.iterator();
-		if (itPred2.hasNext() == true) {
-			pred2 = itPred2.next();
-		}
+		if (itPred2.hasNext() == true) 
+			pred2 = itPred2.next();		
 		
 		graph.removeNode(alternative1);
 		graph.removeNode(alternative2);
@@ -209,20 +194,12 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 				graph.putEdge(alternative1,succ2);	
 			} 
 			else {
-				System.out.println(list.getFirst());
-				System.out.println(list.getLast());
-				System.out.println(graph.nodes());
-				System.out.println("pred2 ="+pred2);
-				System.out.println("pred1 ="+pred1);
-				System.out.println("succ2 ="+succ2);
-				System.out.println("succ1 ="+succ1);
 				graph.putEdge(pred2,alternative1);
 				graph.putEdge(alternative1,succ2);
 				graph.putEdge(pred1,alternative2);
 				graph.putEdge(alternative2,succ1);
 			}		
 		}
-		
 	    Collections.swap(list,list.indexOf(alternative1),list.indexOf(alternative2));
 	}
 

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -2,6 +2,7 @@ package io.github.oliviercailloux.j_voting.preferences.classes;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +36,16 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     	this.voter = voter;
     	this.graph = prefGraph; 
     	this.alternatives = graph.nodes();
+    	this.list = new LinkedList<>();
+    	
+    	Set<Alternative> set = prefGraph.nodes();
+    	Iterator<Alternative> itSet = set.iterator();
+		while (itSet.hasNext() == true) {
+			list.add(itSet.next());
+		}
+    	
+    	
+    	
     }
     
     /**
@@ -131,16 +142,40 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		
 		if(alternative1.equals(alternative2)) 
 			throw new IllegalArgumentException("The alternatives " + alternative1  + " and " + alternative2 + " must be differents.");
+		
+		Alternative pred1 = null;
+		Alternative pred2 = null;
+		Alternative succ1 = null;
+		Alternative succ2 = null;
+		
+		Set<Alternative> setSucc1 = graph.successors(alternative1);
+		Iterator<Alternative> itSucc1 = setSucc1.iterator();
+		if (itSucc1.hasNext() == true) {
+			succ1 = itSucc1.next();
+		}
 
-		Alternative pred1 = (Alternative)graph.predecessors(alternative1);
-		Alternative pred2 = (Alternative)graph.predecessors(alternative2);
-		Alternative succ1 = (Alternative)graph.successors(alternative1);
-		Alternative succ2 = (Alternative)graph.successors(alternative2);
+		Set<Alternative> setSucc2 = graph.successors(alternative2);
+		Iterator<Alternative> itSucc2 = setSucc2.iterator();
+		if (itSucc2.hasNext() == true) {
+			succ2 = itSucc2.next();
+		}
+		
+		Set<Alternative> setPred1 = graph.predecessors(alternative1);
+		Iterator<Alternative> itPred1 = setPred1.iterator();
+		if (itPred1.hasNext() == true) {
+			pred1 = itPred1.next();
+		}
+		
+		Set<Alternative> setPred2 = graph.predecessors(alternative2);
+		Iterator<Alternative> itPred2 = setPred2.iterator();
+		if (itPred2.hasNext() == true) {
+			pred2 = itPred2.next();
+		}
 		
 		graph.removeNode(alternative1);
 		graph.removeNode(alternative2);
 		
-		if (alternative1.equals(list.getFirst())) {						
+		if (alternative1.equals(list.getFirst())) {		
 			if(alternative2.equals(list.getLast())) {				
 				graph.putEdge(alternative2, succ1);
 				graph.putEdge(pred2, alternative1);			
@@ -174,6 +209,13 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 				graph.putEdge(alternative1,succ2);	
 			} 
 			else {
+				System.out.println(list.getFirst());
+				System.out.println(list.getLast());
+				System.out.println(graph.nodes());
+				System.out.println("pred2 ="+pred2);
+				System.out.println("pred1 ="+pred1);
+				System.out.println("succ2 ="+succ2);
+				System.out.println("succ1 ="+succ1);
 				graph.putEdge(pred2,alternative1);
 				graph.putEdge(alternative1,succ2);
 				graph.putEdge(pred1,alternative2);
@@ -182,5 +224,49 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		}
 		
 	    Collections.swap(list,list.indexOf(alternative1),list.indexOf(alternative2));
-	}	
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((alternatives == null) ? 0 : alternatives.hashCode());
+		result = prime * result + ((graph == null) ? 0 : graph.hashCode());
+		result = prime * result + ((list == null) ? 0 : list.hashCode());
+		result = prime * result + ((voter == null) ? 0 : voter.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MutableLinearPreferenceImpl other = (MutableLinearPreferenceImpl) obj;
+		if (alternatives == null) {
+			if (other.alternatives != null)
+				return false;
+		} else if (!alternatives.equals(other.alternatives))
+			return false;
+		if (graph == null) {
+			if (other.graph != null)
+				return false;
+		} else if (!graph.equals(other.graph))
+			return false;
+		if (list == null) {
+			if (other.list != null)
+				return false;
+		} else if (!list.equals(other.list))
+			return false;
+		if (voter == null) {
+			if (other.voter != null)
+				return false;
+		} else if (!voter.equals(other.voter))
+			return false;
+		return true;
+	}
+	
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -22,17 +22,12 @@ import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
 
 public class MutableLinearPreferenceImpl implements MutableLinearPreference {
-	
-	@Override
-	public String toString() {
-		return "MutableLinearPreferenceImpl [voter=" + voter + ", graph=" + graph + ", alternatives=" + alternatives
-				+ ", list=" + list + "]";
-	}
 
 	protected Voter voter;
     protected MutableGraph<Alternative> graph;
     protected Set<Alternative> alternatives;
     protected LinkedList<Alternative> list;
+    protected ImmutableGraph<Alternative> delegate;
     
     private static final Logger LOGGER = LoggerFactory
             .getLogger(MutableLinearPreferenceImpl.class.getName());
@@ -170,9 +165,9 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	@Override
 	public Set<Alternative> getAlternatives() {	
 		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");	
-		Preconditions.checkState(!(alternatives.size() != graph.nodes().size() || !(alternatives.containsAll(graph.nodes()))), "An alternative must not be deleted from the set");
-		
-		return ImmutableSet.copyOf(alternatives);   
+		Preconditions.checkState(!(alternatives.size() != graph.nodes().size() || !(alternatives.containsAll(graph.nodes()))),
+				"An alternative must not be deleted from the set");
+		return ImmutableSet.copyOf(alternatives);  
 	}
 
 	@Override
@@ -183,6 +178,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	@Override
 	public Graph<Alternative> asGraph() {
 		return graph;
+		//return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
 	}
 
 	@Override

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -176,7 +176,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	
 	@Override
 	public Graph<Alternative> asGraph() {
-		return graph;
+		return Graphs.transitiveClosure(graph);
 		//return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
 	}
 

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -91,7 +91,11 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     	}
 		
 	}
-
+	
+	/**
+     * @return an immutable set of all alternatives of the preference
+     * 
+     */
 	@Override
 	public Set<Alternative> getAlternatives() {	
 		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");	

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -59,10 +59,6 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
     		if ((prefGraph.successors(a).size() == 0) && (prefGraph.predecessors(a).size() == 0)) 
     			throw new IllegalArgumentException("There are no edges between all alternatives");
     	}
-    	/*
-    	if (Graphs.hasCycle(prefGraph))
-			throw new IllegalArgumentException("The preference has a cycle");
-    	*/
     	for (Alternative a1 : prefGraph.nodes()) {
             for (Alternative a2 : prefGraph.successors(a1)) {
                 if (Graphs.transitiveClosure(prefGraph).hasEdgeConnecting(a2,a1) && !a2.equals(a1)) {
@@ -84,20 +80,33 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	public void deleteAlternative(Alternative a) {	
 		LOGGER.debug("MutableLinearPreferenceImpl deleteAlternative");
         Preconditions.checkNotNull(a);
-        graph.removeNode(a);	       
-        alternatives = graph.nodes();
+
+        if ((graph.successors(a).size() != 0) && (graph.predecessors(a).size() != 0)) {	
+        	Set<Alternative> setPred = graph.predecessors(a);
+    		Iterator<Alternative> itPred = setPred.iterator();
+    		Alternative pred = itPred.next();
+    				
+    		Set<Alternative> setSucc = graph.successors(a);
+    		Iterator<Alternative> itSucc = setSucc.iterator();
+    		if (itSucc.hasNext() == true) 
+    			graph.putEdge(pred,  itSucc.next());
+		}
+            
+        graph.removeNode(a);
+        list.remove(a);
 	}
 	
 	@Override
 	public void addAlternative(Alternative a) {
 		LOGGER.debug("MutablePreferenceImpl addAlternative");
         Preconditions.checkNotNull(a);
-        graph.addNode(a);
+        
         for (Alternative ai : graph.nodes()) {
-        	if (graph.successors(a).size() == 0)
-    			graph.putEdge(ai, a);
-    	}        
-        alternatives = graph.nodes();
+        	if (graph.successors(ai).size() == 0) {
+    			graph.putEdge(ai, a);        		
+        	}
+    	}
+        list.add(a);
 	}
 	
 	/**

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -1,5 +1,7 @@
 package io.github.oliviercailloux.j_voting.preferences.classes;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -22,6 +24,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	protected Voter voter;
     protected MutableGraph<Alternative> graph;
     protected Set<Alternative> alternatives;
+    
     private static final Logger LOGGER = LoggerFactory
             .getLogger(MutableLinearPreferenceImpl.class.getName());
     
@@ -131,5 +134,35 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	@Override
 	public Graph<Alternative> asGraph() {
 		return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
+	}
+
+	@Override
+	public void reverse(Alternative alternative1, Alternative alternative2) {
+		LOGGER.debug("MutablePreferenceImpl reverse");
+		Preconditions.checkNotNull(alternative1);
+		Preconditions.checkNotNull(alternative2);
+		
+		Set<Alternative> set = new HashSet<>();
+		set.add(alternative1);
+		set.add(alternative2);
+		
+		for(Alternative a : set) {
+			Set<Alternative> predecessor = graph.predecessors(a);
+			Set<Alternative> successor = graph.successors(a);
+			
+			graph.removeNode(a);
+			
+			for(Alternative p : predecessor) {
+				graph.putEdge(p, a);
+			}
+			
+			for(Alternative s : successor) {
+				graph.putEdge(a, s);
+			}
+			
+		}
+			
+		alternatives = graph.nodes();
+
 	}	
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.Graph;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.Graphs;
@@ -167,7 +166,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 		LOGGER.debug("MutableLinearPreferenceImpl getAlternatives");	
 		Preconditions.checkState(!(alternatives.size() != graph.nodes().size() || !(alternatives.containsAll(graph.nodes()))),
 				"An alternative must not be deleted from the set");
-		return ImmutableSet.copyOf(alternatives);  
+		return MutableLinearSetDecorator.given(alternatives);
 	}
 
 	@Override

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImpl.java
@@ -17,7 +17,7 @@ import io.github.oliviercailloux.j_voting.Voter;
 
 import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
 
-public class MutableLinearPreferenceImpl implements MutableLinearPreference{
+public class MutableLinearPreferenceImpl implements MutableLinearPreference {
 	
 	protected Voter voter;
     protected MutableGraph<Alternative> graph;
@@ -32,7 +32,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     }
     
     /**
-     * @param pref  is a mutable graph of alternatives representing the
+     * @param prefGraph is a mutable graph of alternatives representing the
      *              preference. This graph has no cycle.
      * @param voter is the Voter associated to the Preference.
      * @return the mutable linear preference
@@ -43,7 +43,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
     	Preconditions.checkNotNull(prefGraph);
     	boolean testComplete = true;
     	for (Alternative a : prefGraph.nodes()) {
-    		if (testComplete == false)
+    		if (!testComplete)
     			throw new IllegalArgumentException("There are no edges between all alternatives");
     		if (prefGraph.successors(a).size() == 0)
     			testComplete = false;
@@ -76,8 +76,7 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 	public void deleteAlternative(Alternative a) {	
 		LOGGER.debug("MutableLinearPreferenceImpl deleteAlternative");
         Preconditions.checkNotNull(a);
-        graph.removeNode(a);
-		
+        graph.removeNode(a);	
 	}
 	
 	@Override
@@ -89,7 +88,6 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
         	if (graph.successors(a).size() == 0)
     			graph.putEdge(ai, a);
     	}
-		
 	}
 	
 	/**
@@ -113,11 +111,5 @@ public class MutableLinearPreferenceImpl implements MutableLinearPreference{
 	@Override
 	public Graph<Alternative> asGraph() {
 		return ImmutableGraph.copyOf(Graphs.transitiveClosure(graph));
-	}
-
-	
-	
-   
-	
-	
+	}	
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearSetDecorator.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearSetDecorator.java
@@ -1,0 +1,33 @@
+package io.github.oliviercailloux.j_voting.preferences.classes;
+
+import java.util.Collection;
+import java.util.Set;
+
+import com.google.common.collect.ForwardingSet;
+
+import io.github.oliviercailloux.j_voting.Alternative;
+
+public class MutableLinearSetDecorator extends ForwardingSet<Alternative> {
+	
+	protected Set<Alternative> delegate;
+
+	@Override
+	protected Set<Alternative> delegate() {
+		return delegate;
+	}
+	
+	@Override
+	public boolean add(Alternative a) {
+		return false;
+		//throw new IOException("You are trying to modify a Set<Alternative> from MutableLinearPreference");
+	}
+	
+	@Override
+	public boolean addAll(Collection<? extends Alternative> c) {
+		return false;
+		//throw new IOException("You are trying to modify a Set<Alternative> from MutableLinearPreference");
+	}
+	
+	
+
+}

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearSetDecorator.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearSetDecorator.java
@@ -14,37 +14,34 @@ import io.github.oliviercailloux.j_voting.Alternative;
 public class MutableLinearSetDecorator extends ForwardingSet<Alternative> {
 
 	protected Set<Alternative> delegate;
-	
-	private static final Logger LOGGER = LoggerFactory
-            .getLogger(MutableLinearPreferenceImpl.class.getName());
-	
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MutableLinearPreferenceImpl.class.getName());
+
 	private MutableLinearSetDecorator(Set<Alternative> delegate) {
-    	this.delegate = delegate;
-    }
-	
+		this.delegate = delegate;
+	}
+
 	public static MutableLinearSetDecorator given(Set<Alternative> delegate) {
-    	LOGGER.debug("MutableLinearSetDecorator given");
-    	Preconditions.checkNotNull(delegate);
-    	return new MutableLinearSetDecorator(delegate);
-    }
+		LOGGER.debug("MutableLinearSetDecorator given");
+		Preconditions.checkNotNull(delegate);
+		return new MutableLinearSetDecorator(delegate);
+	}
 
 	@Override
 	protected Set<Alternative> delegate() {
 		return delegate;
 	}
-	
+
 	@Override
 	public boolean add(Alternative a) {
 		LOGGER.debug("You are trying to modify a Set<Alternative> from MutableLinearPreference");
 		return false;
 	}
-	
+
 	@Override
 	public boolean addAll(Collection<? extends Alternative> c) {
 		LOGGER.debug("You are trying to modify a Set<Alternative> from MutableLinearPreference");
 		return false;
 	}
-	
-	
 
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearSetDecorator.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearSetDecorator.java
@@ -3,13 +3,30 @@ package io.github.oliviercailloux.j_voting.preferences.classes;
 import java.util.Collection;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ForwardingSet;
 
 import io.github.oliviercailloux.j_voting.Alternative;
 
 public class MutableLinearSetDecorator extends ForwardingSet<Alternative> {
-	
+
 	protected Set<Alternative> delegate;
+	
+	private static final Logger LOGGER = LoggerFactory
+            .getLogger(MutableLinearPreferenceImpl.class.getName());
+	
+	private MutableLinearSetDecorator(Set<Alternative> delegate) {
+    	this.delegate = delegate;
+    }
+	
+	public static MutableLinearSetDecorator given(Set<Alternative> delegate) {
+    	LOGGER.debug("MutableLinearSetDecorator given");
+    	Preconditions.checkNotNull(delegate);
+    	return new MutableLinearSetDecorator(delegate);
+    }
 
 	@Override
 	protected Set<Alternative> delegate() {
@@ -18,14 +35,14 @@ public class MutableLinearSetDecorator extends ForwardingSet<Alternative> {
 	
 	@Override
 	public boolean add(Alternative a) {
+		LOGGER.debug("You are trying to modify a Set<Alternative> from MutableLinearPreference");
 		return false;
-		//throw new IOException("You are trying to modify a Set<Alternative> from MutableLinearPreference");
 	}
 	
 	@Override
 	public boolean addAll(Collection<? extends Alternative> c) {
+		LOGGER.debug("You are trying to modify a Set<Alternative> from MutableLinearPreference");
 		return false;
-		//throw new IOException("You are trying to modify a Set<Alternative> from MutableLinearPreference");
 	}
 	
 	

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -14,7 +14,8 @@ import io.github.oliviercailloux.j_voting.Alternative;
 public interface MutableLinearPreference extends Preference {
 	
 	/**
-	 * Change the order of the alternatives. 
+	 * Change the order of the alternatives. Check if there is a cycle, if all the alternatives are comparable two-by-two
+	 * and if all alternatives are not equals.
 	 * 
 	 * @param newGraph to change the old preference to the new one with an alternative graph.
 	 */
@@ -29,8 +30,7 @@ public interface MutableLinearPreference extends Preference {
 	public void deleteAlternative(Alternative alternative);
 	
 	/**
-	 * Adds an alternative to the Preference. This alternative is not preferred to
-	 * any other of the preference, it is being added isolated.
+	 * Adds an alternative to the Preference. Add a link between the "weakest" alternatives and the new
 	 *
 	 * @param alternative to add to the preference.
 	 */

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -1,14 +1,12 @@
 package io.github.oliviercailloux.j_voting.preferences.interfaces;
 
-import com.google.common.graph.MutableGraph;
-
 import io.github.oliviercailloux.j_voting.Alternative;
 
 /**
  * A mutable linear preference is a mutable antisymmetric complete preference. A mutable linear
  * preference represents a linear order, or equivalently an antisymmetric
  * complete order, or equivalently, the reduction of a weak-order.
- * 
+ * In this preference, it is possible to add alternatives and reorder them
  */
 
 public interface MutableLinearPreference extends Preference {

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -1,0 +1,18 @@
+package io.github.oliviercailloux.j_voting.preferences.interfaces;
+
+import java.util.Set;
+
+
+
+import io.github.oliviercailloux.j_voting.Alternative;
+
+public interface MutableLinearPreference extends MutablePreference{
+	
+	
+	//Méthode de changement de position des alternative
+	public Set<Alternative> changeOrder(Set<Alternative> alternative);
+	
+	//Méthode pour supprimer des alternatives
+	public void deleteAlternative(Alternative a);
+	
+}

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -1,6 +1,7 @@
 package io.github.oliviercailloux.j_voting.preferences.interfaces;
 
-import java.util.Set;
+import com.google.common.graph.MutableGraph;
+
 import io.github.oliviercailloux.j_voting.Alternative;
 
 /**
@@ -16,7 +17,7 @@ public interface MutableLinearPreference extends Preference{
 	 * Change the order of the alternatives
 	 * 
 	 */
-	public Set<Alternative> changeOrder(Set<Alternative> alternative);
+	public void changeOrder(MutableGraph<Alternative> newGraph);
 	
 	/**
 	 * Delete an alternative from the preference

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -24,4 +24,10 @@ public interface MutableLinearPreference extends Preference{
 	 */
 	public void deleteAlternative(Alternative a);
 	
+	/**
+	 * Add an alternative from the preference
+	 * 
+	 */
+	
+	public void addAlternative(Alternative a);
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -1,18 +1,27 @@
 package io.github.oliviercailloux.j_voting.preferences.interfaces;
 
 import java.util.Set;
-
-
-
 import io.github.oliviercailloux.j_voting.Alternative;
 
-public interface MutableLinearPreference extends MutablePreference{
+/**
+ * A mutable linear preference is a mutable antisymmetric complete preference. A mutable linear
+ * preference represents a linear order, or equivalently an antisymmetric
+ * complete order, or equivalently, the reduction of a weak-order.
+ * 
+ */
+
+public interface MutableLinearPreference extends Preference{
 	
-	
-	//Méthode de changement de position des alternative
+	/**
+	 * Change the order of the alternatives
+	 * 
+	 */
 	public Set<Alternative> changeOrder(Set<Alternative> alternative);
 	
-	//Méthode pour supprimer des alternatives
+	/**
+	 * Delete an alternative from the preference
+	 * 
+	 */
 	public void deleteAlternative(Alternative a);
 	
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -14,21 +14,26 @@ import io.github.oliviercailloux.j_voting.Alternative;
 public interface MutableLinearPreference extends Preference{
 	
 	/**
-	 * Change the order of the alternatives
+	 * Change the order of the alternatives. 
 	 * 
+	 * @param newGraph to change the old preference to the new one with an alternative graph.
 	 */
 	public void changeOrder(MutableGraph<Alternative> newGraph);
 	
 	/**
-	 * Delete an alternative from the preference
-	 * 
+	 * Remove an alternative to the Preference. This alternative is deleted as well 
+	 * as the links between it and the other alternatives.
+	 *
+	 * @param alternative to remove to the preference.
 	 */
-	public void deleteAlternative(Alternative a);
+	public void deleteAlternative(Alternative alternative);
 	
 	/**
-	 * Add an alternative from the preference
-	 * 
+	 * Adds an alternative to the Preference. This alternative is not preferred to
+	 * any other of the preference, it is being added isolated.
+	 *
+	 * @param alternative to add to the preference.
 	 */
 	
-	public void addAlternative(Alternative a);
+	public void addAlternative(Alternative alternative);
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -17,9 +17,10 @@ public interface MutableLinearPreference extends Preference {
 	 * Change the order of the alternatives. Check if there is a cycle, if all the alternatives are comparable two-by-two
 	 * and if all alternatives are not equals.
 	 * 
-	 * @param newGraph to change the old preference to the new one with an alternative graph.
+	 * @param alternative that we're going to move in the preference
+	 * @param rank of the alternative
 	 */
-	public void changeOrder(MutableGraph<Alternative> newGraph);
+	public void changeOrder(Alternative alternative, int rank);
 	
 	/**
 	 * Remove an alternative to the Preference. This alternative is deleted as well 
@@ -37,10 +38,10 @@ public interface MutableLinearPreference extends Preference {
 	public void addAlternative(Alternative alternative);
 	
 	/**
-	 * This method enables to switch 2 alternatives in the Set<Alternative> and the MutableGraph<Alternative>
+	 * This method enables to swap 2 alternatives in the LinkedList<Alternative> and the MutableGraph<Alternative>
 	 * 
 	 * @param alternative1 that will change places with alternative2
 	 * @param alternative2 that will change places with alternative1
 	 */
-	public void reverse(Alternative alternative1, Alternative alternative2);
+	public void swap(Alternative alternative1, Alternative alternative2);
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -34,6 +34,13 @@ public interface MutableLinearPreference extends Preference {
 	 *
 	 * @param alternative to add to the preference.
 	 */
-	
 	public void addAlternative(Alternative alternative);
+	
+	/**
+	 * This method enables to switch 2 alternatives in the Set<Alternative> and the MutableGraph<Alternative>
+	 * 
+	 * @param alternative1 that will change places with alternative2
+	 * @param alternative2 that will change places with alternative1
+	 */
+	public void reverse(Alternative alternative1, Alternative alternative2);
 }

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -11,7 +11,7 @@ import io.github.oliviercailloux.j_voting.Alternative;
  * 
  */
 
-public interface MutableLinearPreference extends Preference{
+public interface MutableLinearPreference extends Preference {
 	
 	/**
 	 * Change the order of the alternatives. 

--- a/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
+++ b/src/main/java/io/github/oliviercailloux/j_voting/preferences/interfaces/MutableLinearPreference.java
@@ -14,11 +14,10 @@ import io.github.oliviercailloux.j_voting.Alternative;
 public interface MutableLinearPreference extends Preference {
 	
 	/**
-	 * Change the order of the alternatives. Check if there is a cycle, if all the alternatives are comparable two-by-two
-	 * and if all alternatives are not equals.
+	 * Moves the alternative to the desired rank.
 	 * 
 	 * @param alternative that we're going to move in the preference
-	 * @param rank of the alternative
+	 * @param rank desired
 	 */
 	public void changeOrder(Alternative alternative, int rank);
 	
@@ -26,7 +25,7 @@ public interface MutableLinearPreference extends Preference {
 	 * Remove an alternative to the Preference. This alternative is deleted as well 
 	 * as the links between it and the other alternatives.
 	 *
-	 * @param alternative to remove to the preference.
+	 * @param alternative who belongs to the preference
 	 */
 	public void deleteAlternative(Alternative alternative);
 	
@@ -38,7 +37,7 @@ public interface MutableLinearPreference extends Preference {
 	public void addAlternative(Alternative alternative);
 	
 	/**
-	 * This method enables to swap 2 alternatives in the LinkedList<Alternative> and the MutableGraph<Alternative>
+	 * This method enables to swap 2 different alternatives of the preference.
 	 * 
 	 * @param alternative1 that will change places with alternative2
 	 * @param alternative2 that will change places with alternative1

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -1,0 +1,83 @@
+package io.github.oliviercailloux.j_voting.preferences;
+
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a1;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a2;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a3;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a4;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a5;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.Graphs;
+import com.google.common.graph.MutableGraph;
+
+import io.github.oliviercailloux.j_voting.Alternative;
+import io.github.oliviercailloux.j_voting.Voter;
+import io.github.oliviercailloux.j_voting.preferences.classes.MutableLinearPreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.classes.MutablePreferenceImpl;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
+import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreference;
+
+public class MutableLinearPreferenceImplTest {
+	
+	@Test
+    void testAsGraph() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        graph.putEdge(a1, a2);
+        graph.putEdge(a3, a4);
+        graph.putEdge(a4, a5);
+        graph.putEdge(a5, a3);
+        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        graph.putEdge(a3, a3);
+        graph.putEdge(a4, a4);
+        graph.putEdge(a5, a5);
+        graph.putEdge(a3, a5);
+        graph.putEdge(a4, a3);
+        graph.putEdge(a5, a4);
+        assertEquals(graph, pref.asGraph());
+    }
+	
+
+	/**
+     * Tests whether the single alternative is added to the preferences' graph
+     */
+    @Test
+    void testAddAlternative() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        graph.putEdge(a1, a2);
+        graph.putEdge(a2, a1);
+        
+        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        graph.putEdge(a3, a3);
+        pref.addAlternative(a3);
+        assertEquals(graph, pref.asGraph());
+    }
+    
+    /**
+     * Tests whether the single alternative is removed to the preferences' graph
+     */
+	@Test
+    void testDeleteAlternative() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        
+        graph.putEdge(a1, a2);
+        graph.putEdge(a2, a1);
+        
+        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        pref.addAlternative(a3);
+        
+        pref.deleteAlternative(a3);
+        assertEquals(graph, pref.asGraph());
+    }
+}

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -1,6 +1,7 @@
 package io.github.oliviercailloux.j_voting.preferences;
 
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a1;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a12345;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a2;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a3;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a4;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableGraph;
@@ -22,34 +24,45 @@ import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreferen
 
 public class MutableLinearPreferenceImplTest {
 	
+	
+	
+	@Test
+    void testGiven() {
+		//Test du given mais pas obligatoire je pense 
+	}
+	/**
+     * Tests whether the preference is correctly expressed as a graph
+     */
 	@Test
     void testAsGraph() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(false).build();
+                        .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
-        graph.putEdge(a3, a4);
-        graph.putEdge(a4, a5);
-        graph.putEdge(a5, a3);
+        graph.putEdge(a2, a3);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a3, a5);
-        graph.putEdge(a4, a3);
-        graph.putEdge(a5, a4);
+        
+        graph.putEdge(a1,a1);
+        graph.putEdge(a2,a2);
+        graph.putEdge(a3,a3);
+        
+        graph.putEdge(a1,a3);
+        
         assertEquals(graph, pref.asGraph());
     }
 	
-
 	/**
      * Tests whether the single alternative is added to the preferences' graph
      */
     @Test
     void testAddAlternative() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(false).build();
+                        .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
-        
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-//        graph.putEdge(a3, a1);
-//        pref.addAlternative(a3);
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        graph.putEdge(a3, a3);
+        pref.addAlternative(a3);
         assertEquals(graph, pref.asGraph());
     }
     
@@ -62,14 +75,35 @@ public class MutableLinearPreferenceImplTest {
                         .allowsSelfLoops(true).build();
         
         graph.putEdge(a1, a2);
-        graph.putEdge(a2, a1);
-        
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         graph.putEdge(a1, a1);
         graph.putEdge(a2, a2);
         pref.addAlternative(a3);
-        
         pref.deleteAlternative(a3);
         assertEquals(graph, pref.asGraph());
+    }
+	
+	@Test
+    void testChangeOrder() {
+	
+		//a toi de jouer Léo
+		
+		
+	}
+	
+	 /**
+     * Tests whether method getAlternatives returns a set with all the
+     * alternatives of the preference
+     */
+    @Test
+    void testGetAlternatives() {
+        MutableGraph<Alternative> graph = GraphBuilder.directed()
+                        .allowsSelfLoops(true).build();
+        graph.putEdge(a1, a2);
+        graph.putEdge(a3, a4);
+        graph.putEdge(a5, a5);
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
+        ImmutableSet<Alternative> expected = a12345;
+        assertEquals(expected, pref.getAlternatives());
     }
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -18,9 +18,7 @@ import com.google.common.graph.MutableGraph;
 import io.github.oliviercailloux.j_voting.Alternative;
 import io.github.oliviercailloux.j_voting.Voter;
 import io.github.oliviercailloux.j_voting.preferences.classes.MutableLinearPreferenceImpl;
-import io.github.oliviercailloux.j_voting.preferences.classes.MutablePreferenceImpl;
 import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
-import io.github.oliviercailloux.j_voting.preferences.interfaces.MutablePreference;
 
 public class MutableLinearPreferenceImplTest {
 	
@@ -28,7 +26,7 @@ public class MutableLinearPreferenceImplTest {
 	
 	@Test
     void testGiven() {
-		//Test du given mais pas obligatoire je pense 
+		//Optional
 	}
 	/**
      * Tests whether the preference is correctly expressed as a graph
@@ -41,13 +39,9 @@ public class MutableLinearPreferenceImplTest {
         graph.putEdge(a2, a3);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         
-        graph.putEdge(a1,a1);
-        graph.putEdge(a2,a2);
-        graph.putEdge(a3,a3);
-        
         graph.putEdge(a1,a3);
         
-        assertEquals(graph, pref.asGraph());
+        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
 	
 	/**
@@ -58,12 +52,11 @@ public class MutableLinearPreferenceImplTest {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
                         .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
+        graph.putEdge(a2, a3);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
-        graph.putEdge(a3, a3);
-        pref.addAlternative(a3);
-        assertEquals(graph, pref.asGraph());
+        pref.addAlternative(a4);
+        graph.putEdge(a3, a4);
+        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
     
     /**
@@ -76,19 +69,28 @@ public class MutableLinearPreferenceImplTest {
         
         graph.putEdge(a1, a2);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
         pref.addAlternative(a3);
         pref.deleteAlternative(a3);
-        assertEquals(graph, pref.asGraph());
+        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
 	
 	@Test
     void testChangeOrder() {
 	
-		//a toi de jouer Léo
+		MutableGraph<Alternative> graph1 = GraphBuilder.directed()
+                .allowsSelfLoops(true).build();
+		MutableGraph<Alternative> graph2 = GraphBuilder.directed()
+                .allowsSelfLoops(true).build();
+
+		graph1.putEdge(a1, a2);
+		graph1.putEdge(a2, a3);
 		
+		graph2.putEdge(a3, a2);
+		graph2.putEdge(a2, a1);
 		
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph1));
+		pref.changeOrder(graph2);
+		assertEquals(Graphs.transitiveClosure(graph2), pref.asGraph());	
 	}
 	
 	 /**
@@ -100,8 +102,9 @@ public class MutableLinearPreferenceImplTest {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
                         .allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
+        graph.putEdge(a2, a3);
         graph.putEdge(a3, a4);
-        graph.putEdge(a5, a5);
+        graph.putEdge(a4, a5);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         ImmutableSet<Alternative> expected = a12345;
         assertEquals(expected, pref.getAlternatives());

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -25,17 +25,12 @@ public class MutableLinearPreferenceImplTest {
 	@Test
     void testAsGraph() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+                        .allowsSelfLoops(false).build();
         graph.putEdge(a1, a2);
         graph.putEdge(a3, a4);
         graph.putEdge(a4, a5);
         graph.putEdge(a5, a3);
-        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
-        graph.putEdge(a3, a3);
-        graph.putEdge(a4, a4);
-        graph.putEdge(a5, a5);
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         graph.putEdge(a3, a5);
         graph.putEdge(a4, a3);
         graph.putEdge(a5, a4);
@@ -49,15 +44,12 @@ public class MutableLinearPreferenceImplTest {
     @Test
     void testAddAlternative() {
         MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+                        .allowsSelfLoops(false).build();
         graph.putEdge(a1, a2);
-        graph.putEdge(a2, a1);
         
-        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
-        graph.putEdge(a3, a3);
-        pref.addAlternative(a3);
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
+//        graph.putEdge(a3, a1);
+//        pref.addAlternative(a3);
         assertEquals(graph, pref.asGraph());
     }
     
@@ -72,7 +64,7 @@ public class MutableLinearPreferenceImplTest {
         graph.putEdge(a1, a2);
         graph.putEdge(a2, a1);
         
-        MutableLinearPreference pref = new MutableLinearPreferenceImpl(Voter.createVoter(1), Graphs.copyOf(graph));
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
         graph.putEdge(a1, a1);
         graph.putEdge(a2, a2);
         pref.addAlternative(a3);

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/MutableLinearPreferenceImplTest.java
@@ -22,12 +22,6 @@ import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPr
 
 public class MutableLinearPreferenceImplTest {
 	
-	
-	
-	@Test
-    void testGiven() {
-		//Optional
-	}
 	/**
      * Tests whether the preference is correctly expressed as a graph
      */
@@ -74,6 +68,9 @@ public class MutableLinearPreferenceImplTest {
         assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
 	
+	/**
+     * Tests of the changeOrder method which returns the new preference well
+     */
 	@Test
     void testChangeOrder() {
 	

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -68,27 +68,27 @@ public class MutableLinearPreferenceImplTest {
         assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
     }
 	
-	/**
-     * Tests of the changeOrder method which returns the new preference well
-     */
-	@Test
-    void testChangeOrder() {
-	
-		MutableGraph<Alternative> graph1 = GraphBuilder.directed()
-                .allowsSelfLoops(true).build();
-		MutableGraph<Alternative> graph2 = GraphBuilder.directed()
-                .allowsSelfLoops(true).build();
-
-		graph1.putEdge(a1, a2);
-		graph1.putEdge(a2, a3);
-		
-		graph2.putEdge(a3, a2);
-		graph2.putEdge(a2, a1);
-		
-		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph1));
-		pref.changeOrder(graph2);
-		assertEquals(Graphs.transitiveClosure(graph2), pref.asGraph());	
-	}
+//	/**
+//     * Tests of the changeOrder method which returns the new preference well
+//     */
+//	@Test
+//    void testChangeOrder() {
+//	
+//		MutableGraph<Alternative> graph1 = GraphBuilder.directed()
+//                .allowsSelfLoops(true).build();
+//		MutableGraph<Alternative> graph2 = GraphBuilder.directed()
+//                .allowsSelfLoops(true).build();
+//
+//		graph1.putEdge(a1, a2);
+//		graph1.putEdge(a2, a3);
+//		
+//		graph2.putEdge(a3, a2);
+//		graph2.putEdge(a2, a1);
+//		
+//		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph1));
+//		pref.changeOrder(graph2);
+//		assertEquals(Graphs.transitiveClosure(graph2), pref.asGraph());	
+//	}
 	
 	 /**
      * Tests whether method getAlternatives returns a set with all the

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -6,13 +6,15 @@ import static io.github.oliviercailloux.j_voting.AlternativeHelper.a2;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a3;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a4;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a5;
+import static io.github.oliviercailloux.j_voting.AlternativeHelper.a6;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.LinkedList;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
 
@@ -107,8 +109,11 @@ public class MutableLinearPreferenceImplTest {
         graph.putEdge(a3, a4);
         graph.putEdge(a4, a5);
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
-        ImmutableSet<Alternative> expected = a12345;
+        Set<Alternative> expected = a12345;
         assertEquals(expected, pref.getAlternatives());
+        assertFalse(pref.getAlternatives().add(a6));
+        
+        
     }
     
     @Test

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -8,11 +8,12 @@ import static io.github.oliviercailloux.j_voting.AlternativeHelper.a4;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a5;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.LinkedList;
+
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.graph.GraphBuilder;
-import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableGraph;
 
 import io.github.oliviercailloux.j_voting.Alternative;
@@ -22,20 +23,36 @@ import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPr
 
 public class MutableLinearPreferenceImplTest {
 	
+	@Test
+	void testMutableLinearPreference() {
+		Voter v = Voter.createVoter(1);
+        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+        graph.putEdge(a1, a2);
+        graph.putEdge(a2, a3);
+        MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph);
+        
+        LinkedList<Alternative> list = new LinkedList<Alternative>();
+        list.add(a1);
+        list.add(a2);
+        list.add(a3);
+        MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, list);
+        
+        assertEquals(pref1, pref2);
+    }
+	
 	/**
      * Tests whether the preference is correctly expressed as a graph
      */
 	@Test
     void testAsGraph() {
-        MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
         graph.putEdge(a2, a3);
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
         
-        graph.putEdge(a1,a3);
+        graph.putEdge(a3,a4);
         
-        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
+        assertEquals(graph, pref.asGraph());
     }
 	
 	/**
@@ -84,13 +101,12 @@ public class MutableLinearPreferenceImplTest {
      */
     @Test
     void testGetAlternatives() {
-        MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
         graph.putEdge(a2, a3);
         graph.putEdge(a3, a4);
         graph.putEdge(a4, a5);
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
         ImmutableSet<Alternative> expected = a12345;
         assertEquals(expected, pref.getAlternatives());
     }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -1,4 +1,4 @@
-package io.github.oliviercailloux.j_voting.preferences;
+package io.github.oliviercailloux.j_voting.preferences.classes;
 
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a1;
 import static io.github.oliviercailloux.j_voting.AlternativeHelper.a12345;

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -50,9 +50,13 @@ public class MutableLinearPreferenceImplTest {
         MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
         graph.putEdge(a2, a3);
+        
         MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
         
-        graph.putEdge(a3,a4);
+        graph.putEdge(a1, a3);
+        graph.putEdge(a1, a1);
+        graph.putEdge(a2, a2);
+        graph.putEdge(a3, a3);
         
         assertEquals(graph, pref.asGraph());
     }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -106,4 +106,27 @@ public class MutableLinearPreferenceImplTest {
         ImmutableSet<Alternative> expected = a12345;
         assertEquals(expected, pref.getAlternatives());
     }
+    
+    @Test
+    void testSwap() {
+    	Voter v = Voter.createVoter(1);
+    	MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+    	toTestGraph.putEdge(a1, a2);
+    	toTestGraph.putEdge(a2, a3);
+    	toTestGraph.putEdge(a3, a4);
+    	toTestGraph.putEdge(a4, a5);
+        
+		MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph.putEdge(a1, a4);
+		graph.putEdge(a4, a3);
+		graph.putEdge(a3, a2);
+		graph.putEdge(a2, a5);
+		
+		MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(toTestGraph));
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph));
+		
+		toTestPref.swap(a2,a4);
+		
+		assertEquals(pref, toTestPref);	
+    }
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -105,22 +105,49 @@ public class MutableLinearPreferenceImplTest {
     	toTestGraph.putEdge(a4, a5);
     	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
     	
-    	MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
-		graph.putEdge(a1, a4);
-		graph.putEdge(a4, a2);
-		graph.putEdge(a2, a3);
-		graph.putEdge(a3, a5);		
-		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, graph);
-		
+    	MutableGraph<Alternative> graph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
+    	graph1.putEdge(a1, a4);
+    	graph1.putEdge(a4, a2);
+    	graph1.putEdge(a2, a3);
+    	graph1.putEdge(a3, a5);		
+		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph1);	
 		toTestPref.changeOrder(a4,1);
-		assertEquals(pref, toTestPref);
+		assertEquals(pref1, toTestPref);
+		
+    	MutableGraph<Alternative> graph2 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph2.putEdge(a5, a1);
+		graph2.putEdge(a1, a4);
+		graph2.putEdge(a4, a2);
+		graph2.putEdge(a2, a3);		
+		MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, graph2);
+		toTestPref.changeOrder(a5,0);
+		assertEquals(pref2, toTestPref);
+		
+    	MutableGraph<Alternative> graph3 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph3.putEdge(a5, a4);
+		graph3.putEdge(a4, a2);
+		graph3.putEdge(a2, a1);
+		graph3.putEdge(a1, a3);		
+		MutableLinearPreference pref3 = MutableLinearPreferenceImpl.given(v, graph3);
+		toTestPref.changeOrder(a1,3);
+		assertEquals(pref3, toTestPref);
+		
+    	MutableGraph<Alternative> graph4 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph4.putEdge(a4, a2);
+		graph4.putEdge(a2, a1);
+		graph4.putEdge(a1, a3);
+		graph4.putEdge(a3, a5);		
+		MutableLinearPreference pref4 = MutableLinearPreferenceImpl.given(v, graph4);
+		toTestPref.changeOrder(a5,4);
+		assertEquals(pref4, toTestPref);
     }
     
     /**
  	* Test the 7 cases of the swap method <br/>
  	* a1 -> a2 -> a3 -> a4 -> a5 <br/>
  	* head -> middle -> middle -> middle -> end <br/>
- 	* swap(head,end), swap(head,middle), swap(middle,middle), swap(middle,head), swap(middle,end), swap(end,head), swap(end,middle)
+ 	* swap(head,end), swap(head,middle), swap(middle,middle), swap(middle,head), swap(middle,end), swap(end,head), swap(end,middle) <br/>
+ 	* We have to test 3 additional cases about the neighbours alternatives
  	*/
     @Test
     void testSwap() {

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -24,264 +24,264 @@ import io.github.oliviercailloux.j_voting.preferences.classes.MutableLinearPrefe
 import io.github.oliviercailloux.j_voting.preferences.interfaces.MutableLinearPreference;
 
 public class MutableLinearPreferenceImplTest {
-	
+
 	@Test
 	void testMutableLinearPreference() {
 		Voter v = Voter.createVoter(1);
-        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
-        graph.putEdge(a1, a2);
-        graph.putEdge(a2, a3);
-        MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph);
-        
-        LinkedList<Alternative> list = new LinkedList<Alternative>();
-        list.add(a1);
-        list.add(a2);
-        list.add(a3);
-        MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, list);
-        
-        assertEquals(pref1, pref2);
-    }
-	
-	/**
-     * Tests whether the preference is correctly expressed as a graph
-     */
-	@Test
-    void testAsGraph() {
-        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
-        graph.putEdge(a1, a2);
-        graph.putEdge(a2, a3);
-        
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
-        
-        graph.putEdge(a1, a3);
-        graph.putEdge(a1, a1);
-        graph.putEdge(a2, a2);
-        graph.putEdge(a3, a3);
-        
-        assertEquals(graph, pref.asGraph());
-    }
-	
-	/**
-     * Tests whether the single alternative is added to the preferences
-     */
-    @Test
-    void testAddAlternative() {
-    	Voter v = Voter.createVoter(1);
-    	MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
-        toTestGraph.putEdge(a1, a2);
-        toTestGraph.putEdge(a2, a3);
-        MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
-        
-        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
-        graph.putEdge(a1, a2);
-        graph.putEdge(a2, a3);
-        graph.putEdge(a3, a4);
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v,graph);
+		MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph.putEdge(a1, a2);
+		graph.putEdge(a2, a3);
+		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph);
 
-        toTestPref.addAlternative(a4);
-        assertEquals(toTestPref,pref);
-    }
-    
-    /**
-     * Tests whether the single alternative is removed to the preferences
-     */
+		LinkedList<Alternative> list = new LinkedList<Alternative>();
+		list.add(a1);
+		list.add(a2);
+		list.add(a3);
+		MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, list);
+
+		assertEquals(pref1, pref2);
+	}
+
+	/**
+	 * Tests whether the preference is correctly expressed as a graph
+	 */
 	@Test
-    void testDeleteAlternative() {
+	void testAsGraph() {
+		MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph.putEdge(a1, a2);
+		graph.putEdge(a2, a3);
+
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
+
+		graph.putEdge(a1, a3);
+		graph.putEdge(a1, a1);
+		graph.putEdge(a2, a2);
+		graph.putEdge(a3, a3);
+
+		assertEquals(graph, pref.asGraph());
+	}
+
+	/**
+	 * Tests whether the single alternative is added to the preferences
+	 */
+	@Test
+	void testAddAlternative() {
 		Voter v = Voter.createVoter(1);
-        MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
-        toTestGraph.putEdge(a1, a2);
-        toTestGraph.putEdge(a2, a3);
-        MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
-        
-        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
-        graph.putEdge(a1, a3);
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, graph);
+		MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		toTestGraph.putEdge(a1, a2);
+		toTestGraph.putEdge(a2, a3);
+		MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
 
-        toTestPref.deleteAlternative(a2);
-        assertEquals(toTestPref,pref);
-    }
-	
-	 /**
-     * Tests whether method getAlternatives returns a set with all the
-     * alternatives of the preference
-     */
-    @Test
-    void testGetAlternatives() {
-        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
-        graph.putEdge(a1, a2);
-        graph.putEdge(a2, a3);
-        graph.putEdge(a3, a4);
-        graph.putEdge(a4, a5);
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
-        Set<Alternative> expected = a12345;
-        assertEquals(expected, pref.getAlternatives());
-        assertFalse(pref.getAlternatives().add(a6));
-        
-        
-    }
-    
-    @Test
-    void testChangeOrder(){
-    	Voter v = Voter.createVoter(1);
-    	MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
-    	toTestGraph.putEdge(a1, a2);
-    	toTestGraph.putEdge(a2, a3);
-    	toTestGraph.putEdge(a3, a4);
-    	toTestGraph.putEdge(a4, a5);
-    	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
-    	
-    	MutableGraph<Alternative> graph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
-    	graph1.putEdge(a1, a4);
-    	graph1.putEdge(a4, a2);
-    	graph1.putEdge(a2, a3);
-    	graph1.putEdge(a3, a5);		
-		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph1);	
-		toTestPref.changeOrder(a4,1);
+		MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph.putEdge(a1, a2);
+		graph.putEdge(a2, a3);
+		graph.putEdge(a3, a4);
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, graph);
+
+		toTestPref.addAlternative(a4);
+		assertEquals(toTestPref, pref);
+	}
+
+	/**
+	 * Tests whether the single alternative is removed to the preferences
+	 */
+	@Test
+	void testDeleteAlternative() {
+		Voter v = Voter.createVoter(1);
+		MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		toTestGraph.putEdge(a1, a2);
+		toTestGraph.putEdge(a2, a3);
+		MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
+
+		MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph.putEdge(a1, a3);
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, graph);
+
+		toTestPref.deleteAlternative(a2);
+		assertEquals(toTestPref, pref);
+	}
+
+	/**
+	 * Tests whether method getAlternatives returns a set with all the alternatives
+	 * of the preference
+	 */
+	@Test
+	void testGetAlternatives() {
+		MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph.putEdge(a1, a2);
+		graph.putEdge(a2, a3);
+		graph.putEdge(a3, a4);
+		graph.putEdge(a4, a5);
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), graph);
+		Set<Alternative> expected = a12345;
+		assertEquals(expected, pref.getAlternatives());
+		assertFalse(pref.getAlternatives().add(a6));
+
+	}
+
+	@Test
+	void testChangeOrder() {
+		Voter v = Voter.createVoter(1);
+		MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		toTestGraph.putEdge(a1, a2);
+		toTestGraph.putEdge(a2, a3);
+		toTestGraph.putEdge(a3, a4);
+		toTestGraph.putEdge(a4, a5);
+		MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
+
+		MutableGraph<Alternative> graph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph1.putEdge(a1, a4);
+		graph1.putEdge(a4, a2);
+		graph1.putEdge(a2, a3);
+		graph1.putEdge(a3, a5);
+		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph1);
+		toTestPref.changeOrder(a4, 1);
 		assertEquals(pref1, toTestPref);
-		
-    	MutableGraph<Alternative> graph2 = GraphBuilder.directed().allowsSelfLoops(true).build();
+
+		MutableGraph<Alternative> graph2 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph2.putEdge(a5, a1);
 		graph2.putEdge(a1, a4);
 		graph2.putEdge(a4, a2);
-		graph2.putEdge(a2, a3);		
+		graph2.putEdge(a2, a3);
 		MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, graph2);
-		toTestPref.changeOrder(a5,0);
+		toTestPref.changeOrder(a5, 0);
 		assertEquals(pref2, toTestPref);
-		
-    	MutableGraph<Alternative> graph3 = GraphBuilder.directed().allowsSelfLoops(true).build();
+
+		MutableGraph<Alternative> graph3 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph3.putEdge(a5, a4);
 		graph3.putEdge(a4, a2);
 		graph3.putEdge(a2, a1);
-		graph3.putEdge(a1, a3);		
+		graph3.putEdge(a1, a3);
 		MutableLinearPreference pref3 = MutableLinearPreferenceImpl.given(v, graph3);
-		toTestPref.changeOrder(a1,3);
+		toTestPref.changeOrder(a1, 3);
 		assertEquals(pref3, toTestPref);
-		
-    	MutableGraph<Alternative> graph4 = GraphBuilder.directed().allowsSelfLoops(true).build();
+
+		MutableGraph<Alternative> graph4 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph4.putEdge(a4, a2);
 		graph4.putEdge(a2, a1);
 		graph4.putEdge(a1, a3);
-		graph4.putEdge(a3, a5);		
+		graph4.putEdge(a3, a5);
 		MutableLinearPreference pref4 = MutableLinearPreferenceImpl.given(v, graph4);
-		toTestPref.changeOrder(a5,4);
+		toTestPref.changeOrder(a5, 4);
 		assertEquals(pref4, toTestPref);
-    }
-    
-    /**
- 	* Test the 7 cases of the swap method <br/>
- 	* a1 -> a2 -> a3 -> a4 -> a5 <br/>
- 	* head -> middle -> middle -> middle -> end <br/>
- 	* swap(head,end), swap(head,middle), swap(middle,middle), swap(middle,head), swap(middle,end), swap(end,head), swap(end,middle) <br/>
- 	* We have to test 3 additional cases about the neighbours alternatives
- 	*/
-    @Test
-    void testSwap() {
-    	Voter v = Voter.createVoter(1);
-    	MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
-    	toTestGraph.putEdge(a1, a2);
-    	toTestGraph.putEdge(a2, a3);
-    	toTestGraph.putEdge(a3, a4);
-    	toTestGraph.putEdge(a4, a5);
-    	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
-    	
+	}
+
+	/**
+	 * Test the 7 cases of the swap method <br/>
+	 * a1 -> a2 -> a3 -> a4 -> a5 <br/>
+	 * head -> middle -> middle -> middle -> end <br/>
+	 * swap(head,end), swap(head,middle), swap(middle,middle), swap(middle,head),
+	 * swap(middle,end), swap(end,head), swap(end,middle) <br/>
+	 * We have to test 3 additional cases about the neighbours alternatives
+	 */
+	@Test
+	void testSwap() {
+		Voter v = Voter.createVoter(1);
+		MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		toTestGraph.putEdge(a1, a2);
+		toTestGraph.putEdge(a2, a3);
+		toTestGraph.putEdge(a3, a4);
+		toTestGraph.putEdge(a4, a5);
+		MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
+
 		MutableGraph<Alternative> graph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph1.putEdge(a5, a2);
 		graph1.putEdge(a2, a3);
 		graph1.putEdge(a3, a4);
-		graph1.putEdge(a4, a1);		
+		graph1.putEdge(a4, a1);
 		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph1);
-		toTestPref.swap(a1,a5);	//swap(head,end)
+		toTestPref.swap(a1, a5); // swap(head,end)
 		assertEquals(pref1, toTestPref);
-			
+
 		MutableGraph<Alternative> graph2 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph2.putEdge(a3, a2);
 		graph2.putEdge(a2, a5);
 		graph2.putEdge(a5, a4);
-		graph2.putEdge(a4, a1);		
+		graph2.putEdge(a4, a1);
 		MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, graph2);
-		toTestPref.swap(a5,a3); //swap(head,middle)
+		toTestPref.swap(a5, a3); // swap(head,middle)
 		assertEquals(pref2, toTestPref);
-		
+
 		MutableGraph<Alternative> graph3 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph3.putEdge(a3, a4);
 		graph3.putEdge(a4, a5);
 		graph3.putEdge(a5, a2);
-		graph3.putEdge(a2, a1);		
-		MutableLinearPreference pref3 = MutableLinearPreferenceImpl.given(v, graph3);			
-		toTestPref.swap(a2,a4); //swap(middle,middle)
+		graph3.putEdge(a2, a1);
+		MutableLinearPreference pref3 = MutableLinearPreferenceImpl.given(v, graph3);
+		toTestPref.swap(a2, a4); // swap(middle,middle)
 		assertEquals(pref3, toTestPref);
-		
+
 		MutableGraph<Alternative> graph4 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph4.putEdge(a5, a4);
 		graph4.putEdge(a4, a3);
 		graph4.putEdge(a3, a2);
-		graph4.putEdge(a2, a1);		
+		graph4.putEdge(a2, a1);
 		MutableLinearPreference pref4 = MutableLinearPreferenceImpl.given(v, graph4);
-		toTestPref.swap(a5,a3); //swap(middle,head)
+		toTestPref.swap(a5, a3); // swap(middle,head)
 		assertEquals(pref4, toTestPref);
-		
+
 		MutableGraph<Alternative> graph5 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph5.putEdge(a5, a1);
 		graph5.putEdge(a1, a3);
 		graph5.putEdge(a3, a2);
-		graph5.putEdge(a2, a4);		
+		graph5.putEdge(a2, a4);
 		MutableLinearPreference pref5 = MutableLinearPreferenceImpl.given(v, graph5);
-		toTestPref.swap(a4,a1); //swap(middle,end)
+		toTestPref.swap(a4, a1); // swap(middle,end)
 		assertEquals(pref5, toTestPref);
-		
+
 		MutableGraph<Alternative> graph6 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph6.putEdge(a4, a1);
 		graph6.putEdge(a1, a3);
 		graph6.putEdge(a3, a2);
-		graph6.putEdge(a2, a5);		
+		graph6.putEdge(a2, a5);
 		MutableLinearPreference pref6 = MutableLinearPreferenceImpl.given(v, graph6);
-		toTestPref.swap(a4,a5); //swap(end,head)
+		toTestPref.swap(a4, a5); // swap(end,head)
 		assertEquals(pref6, toTestPref);
-		
+
 		MutableGraph<Alternative> graph7 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph7.putEdge(a4, a1);
 		graph7.putEdge(a1, a5);
 		graph7.putEdge(a5, a2);
-		graph7.putEdge(a2, a3);		
+		graph7.putEdge(a2, a3);
 		MutableLinearPreference pref7 = MutableLinearPreferenceImpl.given(v, graph7);
-		toTestPref.swap(a5,a3); //swap(end,middle)
+		toTestPref.swap(a5, a3); // swap(end,middle)
 		assertEquals(pref7, toTestPref);
-		
+
 		MutableGraph<Alternative> graph8 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph8.putEdge(a4, a1);
 		graph8.putEdge(a1, a2);
 		graph8.putEdge(a2, a5);
-		graph8.putEdge(a5, a3);		
+		graph8.putEdge(a5, a3);
 		MutableLinearPreference pref8 = MutableLinearPreferenceImpl.given(v, graph8);
-		toTestPref.swap(a5,a2); //swap(middle,middle) neighbour 
+		toTestPref.swap(a5, a2); // swap(middle,middle) neighbour
 		assertEquals(pref8, toTestPref);
-		
+
 		MutableGraph<Alternative> graph9 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph9.putEdge(a1, a4);
 		graph9.putEdge(a4, a2);
 		graph9.putEdge(a2, a5);
-		graph9.putEdge(a5, a3);		
+		graph9.putEdge(a5, a3);
 		MutableLinearPreference pref9 = MutableLinearPreferenceImpl.given(v, graph9);
-		toTestPref.swap(a4,a1); //swap(head,middle) neighbour 
+		toTestPref.swap(a4, a1); // swap(head,middle) neighbour
 		assertEquals(pref9, toTestPref);
-		
+
 		MutableGraph<Alternative> graph10 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph10.putEdge(a1, a4);
 		graph10.putEdge(a4, a2);
 		graph10.putEdge(a2, a3);
-		graph10.putEdge(a3, a5);		
+		graph10.putEdge(a3, a5);
 		MutableLinearPreference pref10 = MutableLinearPreferenceImpl.given(v, graph10);
-		toTestPref.swap(a5,a3); //swap(middle,end) neighbour 
+		toTestPref.swap(a5, a3); // swap(middle,end) neighbour
 		assertEquals(pref10, toTestPref);
-		
+
 		MutableGraph<Alternative> toTestGraph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
-    	toTestGraph1.putEdge(a1, a2);
-    	MutableLinearPreference toTestPref1 = MutableLinearPreferenceImpl.given(v, toTestGraph1);
-    	
+		toTestGraph1.putEdge(a1, a2);
+		MutableLinearPreference toTestPref1 = MutableLinearPreferenceImpl.given(v, toTestGraph1);
+
 		MutableGraph<Alternative> graph11 = GraphBuilder.directed().allowsSelfLoops(true).build();
-		graph11.putEdge(a2, a1);		
+		graph11.putEdge(a2, a1);
 		MutableLinearPreference pref11 = MutableLinearPreferenceImpl.given(v, graph11);
-		toTestPref1.swap(a1,a2); //swap(head,end) neighbour 
+		toTestPref1.swap(a1, a2); // swap(head,end) neighbour
 		assertEquals(pref11, toTestPref1);
-    }
+	}
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -107,6 +107,12 @@ public class MutableLinearPreferenceImplTest {
         assertEquals(expected, pref.getAlternatives());
     }
     
+    /**
+ 	* Test the 7 cases of the swap method <br/>
+ 	* a1 -> a2 -> a3 -> a4 -> a5 <br/>
+ 	* head -> middle -> middle -> middle -> end <br/>
+ 	* swap(head,end), swap(head,middle), swap(middle,middle), swap(middle,head), swap(middle,end), swap(end,head), swap(end,middle)
+ 	*/
     @Test
     void testSwap() {
     	Voter v = Voter.createVoter(1);
@@ -115,18 +121,69 @@ public class MutableLinearPreferenceImplTest {
     	toTestGraph.putEdge(a2, a3);
     	toTestGraph.putEdge(a3, a4);
     	toTestGraph.putEdge(a4, a5);
+    	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(toTestGraph));
         
-		MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
-		graph.putEdge(a1, a4);
-		graph.putEdge(a4, a3);
-		graph.putEdge(a3, a2);
-		graph.putEdge(a2, a5);
+		MutableGraph<Alternative> graph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph1.putEdge(a5, a2);
+		graph1.putEdge(a2, a3);
+		graph1.putEdge(a3, a4);
+		graph1.putEdge(a4, a1);		
+		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph1));
+		toTestPref.swap(a1,a5);	//swap(head,end)
+		assertEquals(pref1, toTestPref);
+			
+		MutableGraph<Alternative> graph2 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph2.putEdge(a3, a2);
+		graph2.putEdge(a2, a5);
+		graph2.putEdge(a5, a4);
+		graph2.putEdge(a4, a1);		
+		MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph2));
+		toTestPref.swap(a5,a3); //swap(head,middle)
+		assertEquals(pref2, toTestPref);
 		
-		MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(toTestGraph));
-		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph));
+		MutableGraph<Alternative> graph3 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph3.putEdge(a3, a4);
+		graph3.putEdge(a4, a5);
+		graph3.putEdge(a5, a2);
+		graph3.putEdge(a2, a1);		
+		MutableLinearPreference pref3 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph3));			
+		toTestPref.swap(a2,a4); //swap(middle,middle)
+		assertEquals(pref3, toTestPref);
 		
-		toTestPref.swap(a2,a4);
+		MutableGraph<Alternative> graph4 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph4.putEdge(a5, a4);
+		graph4.putEdge(a4, a3);
+		graph4.putEdge(a3, a2);
+		graph4.putEdge(a2, a1);		
+		MutableLinearPreference pref4 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph4));
+		toTestPref.swap(a5,a3); //swap(middle,head)
+		assertEquals(pref4, toTestPref);
 		
-		assertEquals(pref, toTestPref);	
+		MutableGraph<Alternative> graph5 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph5.putEdge(a5, a1);
+		graph5.putEdge(a1, a3);
+		graph5.putEdge(a3, a2);
+		graph5.putEdge(a2, a4);		
+		MutableLinearPreference pref5 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph5));
+		toTestPref.swap(a4,a1); //swap(middle,end)
+		assertEquals(pref5, toTestPref);
+		
+		MutableGraph<Alternative> graph6 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph6.putEdge(a4, a1);
+		graph6.putEdge(a1, a3);
+		graph6.putEdge(a3, a2);
+		graph6.putEdge(a2, a5);		
+		MutableLinearPreference pref6 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph6));
+		toTestPref.swap(a4,a5); //swap(end,head)
+		assertEquals(pref6, toTestPref);
+		
+		MutableGraph<Alternative> graph7 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph7.putEdge(a4, a1);
+		graph7.putEdge(a1, a5);
+		graph7.putEdge(a5, a2);
+		graph7.putEdge(a2, a3);		
+		MutableLinearPreference pref7 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph7));
+		toTestPref.swap(a5,a3); //swap(end,middle)
+		assertEquals(pref7, toTestPref);
     }
 }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -39,33 +39,43 @@ public class MutableLinearPreferenceImplTest {
     }
 	
 	/**
-     * Tests whether the single alternative is added to the preferences' graph
+     * Tests whether the single alternative is added to the preferences
      */
     @Test
     void testAddAlternative() {
-        MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+    	Voter v = Voter.createVoter(1);
+    	MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+        toTestGraph.putEdge(a1, a2);
+        toTestGraph.putEdge(a2, a3);
+        MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
+        
+        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
         graph.putEdge(a1, a2);
         graph.putEdge(a2, a3);
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        pref.addAlternative(a4);
         graph.putEdge(a3, a4);
-        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v,graph);
+
+        toTestPref.addAlternative(a4);
+        assertEquals(toTestPref,pref);
     }
     
     /**
-     * Tests whether the single alternative is removed to the preferences' graph
+     * Tests whether the single alternative is removed to the preferences
      */
 	@Test
     void testDeleteAlternative() {
-        MutableGraph<Alternative> graph = GraphBuilder.directed()
-                        .allowsSelfLoops(true).build();
+		Voter v = Voter.createVoter(1);
+        MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+        toTestGraph.putEdge(a1, a2);
+        toTestGraph.putEdge(a2, a3);
+        MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
         
-        graph.putEdge(a1, a2);
-        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph));
-        pref.addAlternative(a3);
-        pref.deleteAlternative(a3);
-        assertEquals(Graphs.transitiveClosure(graph), pref.asGraph());
+        MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+        graph.putEdge(a1, a3);
+        MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, graph);
+
+        toTestPref.deleteAlternative(a2);
+        assertEquals(toTestPref,pref);
     }
 	
 //	/**
@@ -121,14 +131,14 @@ public class MutableLinearPreferenceImplTest {
     	toTestGraph.putEdge(a2, a3);
     	toTestGraph.putEdge(a3, a4);
     	toTestGraph.putEdge(a4, a5);
-    	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(toTestGraph));
+    	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
         
 		MutableGraph<Alternative> graph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph1.putEdge(a5, a2);
 		graph1.putEdge(a2, a3);
 		graph1.putEdge(a3, a4);
 		graph1.putEdge(a4, a1);		
-		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph1));
+		MutableLinearPreference pref1 = MutableLinearPreferenceImpl.given(v, graph1);
 		toTestPref.swap(a1,a5);	//swap(head,end)
 		assertEquals(pref1, toTestPref);
 			
@@ -137,7 +147,7 @@ public class MutableLinearPreferenceImplTest {
 		graph2.putEdge(a2, a5);
 		graph2.putEdge(a5, a4);
 		graph2.putEdge(a4, a1);		
-		MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph2));
+		MutableLinearPreference pref2 = MutableLinearPreferenceImpl.given(v, graph2);
 		toTestPref.swap(a5,a3); //swap(head,middle)
 		assertEquals(pref2, toTestPref);
 		
@@ -146,7 +156,7 @@ public class MutableLinearPreferenceImplTest {
 		graph3.putEdge(a4, a5);
 		graph3.putEdge(a5, a2);
 		graph3.putEdge(a2, a1);		
-		MutableLinearPreference pref3 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph3));			
+		MutableLinearPreference pref3 = MutableLinearPreferenceImpl.given(v, graph3);			
 		toTestPref.swap(a2,a4); //swap(middle,middle)
 		assertEquals(pref3, toTestPref);
 		
@@ -155,7 +165,7 @@ public class MutableLinearPreferenceImplTest {
 		graph4.putEdge(a4, a3);
 		graph4.putEdge(a3, a2);
 		graph4.putEdge(a2, a1);		
-		MutableLinearPreference pref4 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph4));
+		MutableLinearPreference pref4 = MutableLinearPreferenceImpl.given(v, graph4);
 		toTestPref.swap(a5,a3); //swap(middle,head)
 		assertEquals(pref4, toTestPref);
 		
@@ -164,7 +174,7 @@ public class MutableLinearPreferenceImplTest {
 		graph5.putEdge(a1, a3);
 		graph5.putEdge(a3, a2);
 		graph5.putEdge(a2, a4);		
-		MutableLinearPreference pref5 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph5));
+		MutableLinearPreference pref5 = MutableLinearPreferenceImpl.given(v, graph5);
 		toTestPref.swap(a4,a1); //swap(middle,end)
 		assertEquals(pref5, toTestPref);
 		
@@ -173,7 +183,7 @@ public class MutableLinearPreferenceImplTest {
 		graph6.putEdge(a1, a3);
 		graph6.putEdge(a3, a2);
 		graph6.putEdge(a2, a5);		
-		MutableLinearPreference pref6 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph6));
+		MutableLinearPreference pref6 = MutableLinearPreferenceImpl.given(v, graph6);
 		toTestPref.swap(a4,a5); //swap(end,head)
 		assertEquals(pref6, toTestPref);
 		
@@ -182,7 +192,7 @@ public class MutableLinearPreferenceImplTest {
 		graph7.putEdge(a1, a5);
 		graph7.putEdge(a5, a2);
 		graph7.putEdge(a2, a3);		
-		MutableLinearPreference pref7 = MutableLinearPreferenceImpl.given(v, Graphs.copyOf(graph7));
+		MutableLinearPreference pref7 = MutableLinearPreferenceImpl.given(v, graph7);
 		toTestPref.swap(a5,a3); //swap(end,middle)
 		assertEquals(pref7, toTestPref);
     }

--- a/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
+++ b/src/test/java/io/github/oliviercailloux/j_voting/preferences/classes/MutableLinearPreferenceImplTest.java
@@ -78,28 +78,6 @@ public class MutableLinearPreferenceImplTest {
         assertEquals(toTestPref,pref);
     }
 	
-//	/**
-//     * Tests of the changeOrder method which returns the new preference well
-//     */
-//	@Test
-//    void testChangeOrder() {
-//	
-//		MutableGraph<Alternative> graph1 = GraphBuilder.directed()
-//                .allowsSelfLoops(true).build();
-//		MutableGraph<Alternative> graph2 = GraphBuilder.directed()
-//                .allowsSelfLoops(true).build();
-//
-//		graph1.putEdge(a1, a2);
-//		graph1.putEdge(a2, a3);
-//		
-//		graph2.putEdge(a3, a2);
-//		graph2.putEdge(a2, a1);
-//		
-//		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(Voter.createVoter(1), Graphs.copyOf(graph1));
-//		pref.changeOrder(graph2);
-//		assertEquals(Graphs.transitiveClosure(graph2), pref.asGraph());	
-//	}
-	
 	 /**
      * Tests whether method getAlternatives returns a set with all the
      * alternatives of the preference
@@ -117,6 +95,27 @@ public class MutableLinearPreferenceImplTest {
         assertEquals(expected, pref.getAlternatives());
     }
     
+    @Test
+    void testChangeOrder(){
+    	Voter v = Voter.createVoter(1);
+    	MutableGraph<Alternative> toTestGraph = GraphBuilder.directed().allowsSelfLoops(true).build();
+    	toTestGraph.putEdge(a1, a2);
+    	toTestGraph.putEdge(a2, a3);
+    	toTestGraph.putEdge(a3, a4);
+    	toTestGraph.putEdge(a4, a5);
+    	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
+    	
+    	MutableGraph<Alternative> graph = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph.putEdge(a1, a4);
+		graph.putEdge(a4, a2);
+		graph.putEdge(a2, a3);
+		graph.putEdge(a3, a5);		
+		MutableLinearPreference pref = MutableLinearPreferenceImpl.given(v, graph);
+		
+		toTestPref.changeOrder(a4,1);
+		assertEquals(pref, toTestPref);
+    }
+    
     /**
  	* Test the 7 cases of the swap method <br/>
  	* a1 -> a2 -> a3 -> a4 -> a5 <br/>
@@ -132,7 +131,7 @@ public class MutableLinearPreferenceImplTest {
     	toTestGraph.putEdge(a3, a4);
     	toTestGraph.putEdge(a4, a5);
     	MutableLinearPreference toTestPref = MutableLinearPreferenceImpl.given(v, toTestGraph);
-        
+    	
 		MutableGraph<Alternative> graph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
 		graph1.putEdge(a5, a2);
 		graph1.putEdge(a2, a3);
@@ -195,5 +194,42 @@ public class MutableLinearPreferenceImplTest {
 		MutableLinearPreference pref7 = MutableLinearPreferenceImpl.given(v, graph7);
 		toTestPref.swap(a5,a3); //swap(end,middle)
 		assertEquals(pref7, toTestPref);
+		
+		MutableGraph<Alternative> graph8 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph8.putEdge(a4, a1);
+		graph8.putEdge(a1, a2);
+		graph8.putEdge(a2, a5);
+		graph8.putEdge(a5, a3);		
+		MutableLinearPreference pref8 = MutableLinearPreferenceImpl.given(v, graph8);
+		toTestPref.swap(a5,a2); //swap(middle,middle) neighbour 
+		assertEquals(pref8, toTestPref);
+		
+		MutableGraph<Alternative> graph9 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph9.putEdge(a1, a4);
+		graph9.putEdge(a4, a2);
+		graph9.putEdge(a2, a5);
+		graph9.putEdge(a5, a3);		
+		MutableLinearPreference pref9 = MutableLinearPreferenceImpl.given(v, graph9);
+		toTestPref.swap(a4,a1); //swap(head,middle) neighbour 
+		assertEquals(pref9, toTestPref);
+		
+		MutableGraph<Alternative> graph10 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph10.putEdge(a1, a4);
+		graph10.putEdge(a4, a2);
+		graph10.putEdge(a2, a3);
+		graph10.putEdge(a3, a5);		
+		MutableLinearPreference pref10 = MutableLinearPreferenceImpl.given(v, graph10);
+		toTestPref.swap(a5,a3); //swap(middle,end) neighbour 
+		assertEquals(pref10, toTestPref);
+		
+		MutableGraph<Alternative> toTestGraph1 = GraphBuilder.directed().allowsSelfLoops(true).build();
+    	toTestGraph1.putEdge(a1, a2);
+    	MutableLinearPreference toTestPref1 = MutableLinearPreferenceImpl.given(v, toTestGraph1);
+    	
+		MutableGraph<Alternative> graph11 = GraphBuilder.directed().allowsSelfLoops(true).build();
+		graph11.putEdge(a2, a1);		
+		MutableLinearPreference pref11 = MutableLinearPreferenceImpl.given(v, graph11);
+		toTestPref1.swap(a1,a2); //swap(head,end) neighbour 
+		assertEquals(pref11, toTestPref1);
     }
 }


### PR DESCRIPTION
Notre objectif était d’améliorer la classe MutableLinearPreference en basant son implémentation sur
une List<Alternative> plutôt que sur un Graph<Alternative>. La classe maintient à la fois le
Graph<Alternative> et la List<Alternative> à jour.

Plus précisément, nous avons travaillé sur différents points :
- Ajout d’un attribut List<Alternative>
- Modification du constructeur MutableLinearPreferenceImpl(Voter voter,
MutableGraph<Alternative> prefGraph)
- Ajout du constructeur MutableLinearPreferenceImpl(Voter voter, List<Alternative> list)
- Création de la méthode swap(Alternative a1, Alternative a2) qui intervertit deux alternatives
au sein d’une préférence
- Refonte de la méthode changeOrder(Alternative a, int rank) qui déplace une alternative au
rang donné au sein d’une préférence
- Création d’une classe MutableLinearSetDecorator
- Ajout de l’enrobage dans getAlternative()
- Modification de addAlternative(Alternative a) et deleteAlternative(Alternative a)
- Concernant la méthode asGraph(), certaines questions restent en suspens (cf pull request
MutableLinearPreference – itération 1) et nous avons décidé de ne pas modifier l’ancienne
version en attendant vos réponses pour respecter le contrat.
- Création des tests pour tous les cas de swap() et changeOrder()
- Création de tests pour les constructeurs
- Modification des tests de addAlternative() et deleteAlternative()
- Optimisation des tests avec la suppression des copyOf() et des transitiveClosure()

Dev : Léo & Thomas
SM/PO : Pierre